### PR TITLE
Make sure that $NewVersion is a string when set.

### DIFF
--- a/Extensions/Versioning/VersionVSIXTask/ApplyVersionToVSIX.ps1
+++ b/Extensions/Versioning/VersionVSIXTask/ApplyVersionToVSIX.ps1
@@ -69,7 +69,7 @@ if($files)
         attrib $file -r
 
         $node = $xml.PackageManifest.Metadata.Identity
-        $node.Version = $NewVersion
+        $node.Version = [string]$NewVersion
 
         $xml.Save($file)
         Write-Verbose "$file - version applied"


### PR DESCRIPTION
Make sure that $NewVersion is a string when set. Otherwise the following error might occur: 

```
System.Management.Automation.SetValueException: Cannot set "Version" because only strings can be used as values to set XmlNode properties.
```
