### PR TITLE
Set only the first two digits of the version.

### DIFF
--- a/Extensions/Versioning/VersionVSIXTask/ApplyVersionToVSIX.ps1
+++ b/Extensions/Versioning/VersionVSIXTask/ApplyVersionToVSIX.ps1
@@ -55,7 +55,9 @@ switch($VersionData.Count)
          Write-Warning "Will assume first instance is version."
       }
 }
-$NewVersion = $VersionData[0]
+
+# we only want the first two blocks
+$NewVersion = [String]::Format("{0}.{1}", $VersionData[0].Value.Split(".")[0], $VersionData[0].Value.Split(".")[1])
 Write-Verbose "Version: $NewVersion"
 
 # Apply the version to the assembly property files


### PR DESCRIPTION
Set only the first two digits of the version as it is described in the comment of the task, but wasn't currently implemented. Took logic from PS version of the script.