### PR TITLE
Additional input for passing version number

### DIFF
--- a/Extensions/Versioning/VersionVSIXTask/ApplyVersionToVSIX.ps1
+++ b/Extensions/Versioning/VersionVSIXTask/ApplyVersionToVSIX.ps1
@@ -19,6 +19,9 @@ param (
     [String]$Path,
 
     [Parameter(Mandatory)]
+    [string]$VersionNumberOnly,
+
+    [Parameter(Mandatory)]
     [string]$VersionNumber
 )
 
@@ -37,25 +40,32 @@ if (-not (Test-Path $Path))
     exit 1
 }
 Write-Verbose "Source Directory: $Path"
-Write-Verbose "Version Number: $VersionNumber"
+Write-Verbose "Version number: $VersionNumberOnly"
+Write-Verbose "Build name: $VersionNumber"
 
-# Get and validate the version data
-$VersionData = [regex]::matches($VersionNumber,$VersionRegex)
-switch($VersionData.Count)
+if ($VersionNumberOnly) 
 {
-   0        
-      { 
-         Write-Error "Could not find version number data in $VersionNumber."
-         exit 1
-      }
-   1 {}
-   default 
-      { 
-         Write-Warning "Found more than instance of version data in $VersionNumber." 
-         Write-Warning "Will assume first instance is version."
-      }
+    $NewVersion = $VersionNumberOnly
 }
-$NewVersion = $VersionData[0]
+else 
+{
+    # Get and validate the version data
+    $VersionData = [regex]::matches($VersionNumber,$VersionRegex)
+    switch($VersionData.Count)
+    {
+        0 { 
+            Write-Error "Could not find version number data in $VersionNumber."
+            exit 1
+        }
+        1 {}
+        default 
+        {
+            Write-Warning "Found more than instance of version data in $VersionNumber." 
+            Write-Warning "Will assume first instance is version."
+        }
+    }
+    $NewVersion = $VersionData[0]
+}
 Write-Verbose "Version: $NewVersion"
 
 # Apply the version to the assembly property files

--- a/Extensions/Versioning/VersionVSIXTask/task.json
+++ b/Extensions/Versioning/VersionVSIXTask/task.json
@@ -24,12 +24,20 @@
          "helpMarkDown": "Source folder for VSIX files, can be root as it will find all files recursively"
       },
       {
+         "name": "VersionNumberOnly",
+         "type": "string",
+         "label": "Version number",
+         "defaultValue": "",
+         "required": false,
+         "helpMarkDown": "Version number to apply to files. You need either to set the version number or build name."
+      },      
+      {
          "name": "VersionNumber",
          "type": "string",
-         "label": "Version Number",
+         "label": "Build name",
          "defaultValue": "$(Build.BuildNumber)",
-         "required": true,
-         "helpMarkDown": "Version number to apply to files, can be extraced from the build name 'Build HelloWorld_00.00.00000.0' format"
+         "required": false,
+         "helpMarkDown": "Build name (in 'Build HelloWorld_00.00.00000.0' format) from which the version should be extracted. You need either to set the version number or build name."
       }
    ],
   "minimumAgentVersion": "1.82.0",


### PR DESCRIPTION
Add an additional input for passing version number. Rename existing input to "Build name".

Fixes #25 