### PR TITLE
Force UTF-8 Encoding when reading the NuSpec

### DIFF
--- a/Extensions/Versioning/VersionNuspecTask/ApplyVersionToNuspec.ps1
+++ b/Extensions/Versioning/VersionNuspecTask/ApplyVersionToNuspec.ps1
@@ -65,7 +65,7 @@ if($files)
 
     foreach ($file in $files) {
 
-        $xml = [xml](get-content -Path $file)
+        $xml = [xml](get-content -Path $file -Encoding UTF8)
         $xml.SelectSingleNode("/package/metadata/version").InnerText = $NewVersion
         write-verbose -Verbose "Updated the file $file with the version $NewVersion"
         $xml.Save($file)


### PR DESCRIPTION
Hi! First of all, thanks to the AWESOME plugin. Good work!
I found one minor issue when my Nuget description has special characters, even if the encoding is defined on the XML tag like this:
<?xml version="1.0" encoding="UTF-8"?>
So, if you force UTF-8 it via the Get-Content we would be on safe side.