### PR TITLE
Added variable as markdown output

### DIFF
--- a/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.ps1
+++ b/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.ps1
@@ -31,6 +31,9 @@ param (
     [parameter(Mandatory=$false,HelpMessage="The markdown output file")]
     $outputfile ,
 
+    [parameter(Mandatory=$false,HelpMessage="The markdown output variable name")]
+    $outputvariablename ,
+
     [parameter(Mandatory=$false,HelpMessage="The markdown template file")]
     $templatefile ,
 	
@@ -499,6 +502,7 @@ Write-Verbose "overrideStageName = [$overrideStageName]"
 Write-Verbose "buildid = [$env:BUILD_BUILDID]"
 Write-Verbose "defname = [$env:BUILD_DEFINITIONNAME]"
 Write-Verbose "buildnumber = [$env:BUILD_BUILDNUMBER]"
+Write-Verbose "outputVariableName = [$outputvariablename]"
 
 
 if ( [string]::IsNullOrEmpty($releaseid))
@@ -598,6 +602,16 @@ $outputmarkdown = Process-Template -template $template -builds $builds
 
 write-Verbose "Writing output file [$outputfile]."
 Set-Content $outputfile $outputmarkdown
+
+if ([string]::IsNullOrEmpty($outputvariablename))
+{
+    write-Verbose "Skipping setting output variable name as parameter was not set."
+} 
+else 
+{    
+    Write-Verbose "Setting variable: [$outputvariablename] = $outputmarkdown" -Verbose
+    Write-Host ("##vso[task.setvariable variable=$outputvariablename;]$outputmarkdown")
+}
 
 
 

--- a/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/task.json
+++ b/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/task.json
@@ -33,6 +33,14 @@
          "helpMarkDown": "The name of the Markdown file to export e.g. $(Build.ArtifactStagingDirectory)\\releasenotes.md if within a build workflow "
       },
       {
+         "name": "outputVariableName",
+         "type": "string",
+         "label": "Output variable",
+         "defaultValue": "",
+         "required": false,
+         "helpMarkDown": "The name of the variable that the markdown output should be assigned to for use later in your workflow."
+      },
+      {
       "name": "templateLocation",
       "type": "pickList",
       "label": "Template Location",


### PR DESCRIPTION
Added the ability to (optionally) set the markdown output to a variable.  This can be useful if you want to use the contents later on in your pipeline.

One issue I have is that all the documentation I have found for setting the variable requires the use of **Write-Host** which appears to remove the verbose logs when **system.debug** is set to true.