### PR TITLE
[FIX] Using UseDefaultCredentials instead of AccessToken

### DIFF
--- a/Extensions/BuildUpdating/BuildVariableTask/BuildVariableTask.ps1
+++ b/Extensions/BuildUpdating/BuildVariableTask/BuildVariableTask.ps1
@@ -32,10 +32,8 @@ function Set-BuildDefinationVariable
 function Get-WebClient
 {
 
-    $vssEndPoint = Get-ServiceEndPoint -Name "SystemVssConnection" -Context $distributedTaskContext
-    $personalAccessToken = $vssEndpoint.Authorization.Parameters.AccessToken
     $webclient = new-object System.Net.WebClient
-    $webclient.Headers.Add("Authorization" ,"Bearer $personalAccessToken")
+    $webclient.UseDefaultCredentials = $true
 
     $webclient.Encoding = [System.Text.Encoding]::UTF8
     $webclient.Headers["Content-Type"] = "application/json"


### PR DESCRIPTION
Then got "(403) Forbidden"

Edit build definitions right sets crrectly
"Allow scripts to access OAuth token" marked on my environments
Helps me "UseDefaultCredentials" on webclient instead of Bearer token:
#$webclient.Headers.Add("Authorization" ,"Bearer $personalAccessToken") $webclient.UseDefaultCredentials = $true