### PR TITLE
skip commits with no description

### DIFF
--- a/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.psm1
+++ b/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.psm1
@@ -50,6 +50,7 @@ function Get-BuildChangeSets
         $jsondata = Invoke-GetCommand -uri $uri -usedefaultcreds $usedefaultcreds | ConvertFrom-Json
         foreach ($cs in $jsondata.value)
         {
+	if (!$cs.message) {continue} # skip commits with no description
         # we can get more detail if the changeset is on VSTS or TFS
         try {
             $csList += Get-Detail -uri $cs.location -usedefaultcreds $usedefaultcreds


### PR DESCRIPTION
per the second bullet of my request #75

i see the complexity of skipping whole sections per your initial response to my first bullet, but still wondering if something like this would work for skipping individual items?

if that works - probably best to make optional via additional configuration boolean?