### PR TITLE
Tag and ExcludeTag not an array when passed from VSTS

### DIFF
--- a/Extensions/Pester/PesterTask/Pester.ps1
+++ b/Extensions/Pester/PesterTask/Pester.ps1
@@ -84,10 +84,12 @@ $Parameters = @{
 
 if ($Tag)
 {
+    $Tag = $Tag.Split(',').Replace('"','').Replace("'","")
     $Parameters.Add('Tag',$Tag)
 }
 if ($ExcludeTag)
 {
+    $ExcludeTag = $ExcludeTag.Split(',').Replace('"','').Replace("'","")
     $Parameters.Add('ExcludeTag',$ExcludeTag)
 }
 

--- a/Tests/Extensions/Pester/PesterTask/Pester.Tests.ps1
+++ b/Tests/Extensions/Pester/PesterTask/Pester.Tests.ps1
@@ -45,8 +45,32 @@ Describe "Testing Pester Task" {
         it "Tag is not Mandatory" {
             (Get-Command $sut).Parameters['Tag'].Attributes.Mandatory | Should Be $False
         }
+        it "Calls Invoke-Pester with multiple Tags specified" {
+            mock Invoke-Pester { }
+            mock Import-Module { }
+            Mock Write-Verbose { }
+            Mock Write-Warning { }
+            Mock Write-Error { }
+
+            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -Tag 'Infrastructure,Integration'
+            $Tag.Length | Should Be 2
+            Write-Output -NoEnumerate $Tag | Should BeOfType [System.Array]
+            Write-Output -NoEnumerate $Tag | Should BeOfType [String[]]
+        }
         it "ExcludeTag is not Mandatory" {
             (Get-Command $sut).Parameters['ExcludeTag'].Attributes.Mandatory | Should Be $False
+        }       
+        it "Calls Invoke-Pester with multiple ExcludeTags specified" {
+            mock Invoke-Pester { }
+            mock Import-Module { }
+            Mock Write-Verbose { }
+            Mock Write-Warning { }
+            Mock Write-Error { }
+            
+            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ExcludeTag 'Example,Demo'
+            $ExcludeTag.Length | Should be 2
+            Write-Output -NoEnumerate $ExcludeTag | Should BeOfType [System.Array]
+            Write-Output -NoEnumerate $ExcludeTag | Should BeOfType [String[]]
         }
 
     }

--- a/Tests/Extensions/Pester/PesterTask/Pester.Tests.ps1
+++ b/Tests/Extensions/Pester/PesterTask/Pester.Tests.ps1
@@ -28,6 +28,17 @@ Describe "Testing Pester Task" {
         it "Throws Exception when passed a path which doesn't contain Pester for ModuleFolder" {
             {&$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder TestDrive:\} | Should Throw
         }
+        it "Continues when passed a null ModuleFolder as VSTS task does" {
+            mock Invoke-Pester { }
+            mock Import-Module { }
+            Mock Write-Verbose { }
+            Mock Write-Warning { }
+            Mock Write-Error { }
+
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder $null
+            Assert-MockCalled Invoke-Pester
+            
+        }
         it "ModuleFolder is not Mandatory" {
             (Get-Command $sut).Parameters['ModuleFolder'].Attributes.Mandatory | Should Be $False
         }


### PR DESCRIPTION
VSTS passes a string for it's tasks as it can't handle arrays correctly for parameters. 

This will now split that on commas and then strip single and double quotes. Tests have also been added to verify this. 