### PR TITLE
Fix for line endings issue when using variable

### DIFF
--- a/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.ps1
+++ b/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.ps1
@@ -190,7 +190,8 @@ else
     # is returned as in the output varibable if we just try to pipe the local variable
     $file = Get-Content $outputfile
     Write-Verbose "Setting variable: [$outputvariablename] = $file" -Verbose
-    Write-Host ("##vso[task.setvariable variable=$outputvariablename;]$file")
+    $joined = $file -join '`n'
+    Write-Host ("##vso[task.setvariable variable=$outputvariablename;]$joined")
 }
 
 


### PR DESCRIPTION
When I was trying to use the variable in an email task, all the line endings were removed.  This fixes it for me.  

I am worried this regresses #69, I can't replicate it, so I don't think it does.