### PR TITLE
Altered DacPac filter exlude master and msdb.

### DIFF
--- a/Extensions/Versioning/VersionDacpacTask/Update-DacPacVersionNumber.ps1
+++ b/Extensions/Versioning/VersionDacpacTask/Update-DacPacVersionNumber.ps1
@@ -188,7 +188,7 @@ $NewVersion = $VersionData[0]
 Write-Verbose "Version: $NewVersion"
 
 
-$DacPacFiles = Get-ChildItem -Path $Path -Filter *.dacpac -Recurse
+$DacPacFiles = Get-ChildItem -Path $Path -Include *.dacpac -Exclude master.dacpac,msdb.dacpac -Recurse
 
 Write-Verbose "Found $($DacPacFiles.Count) dacpacs. Beginning to apply updated version number $NewVersion." -Verbose
 

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -13,6 +13,7 @@ V1.10.x - Fixed file encoding issue
 V1.11.x - Allows a filename pattern to be entered as a parameter for Assembly Versioning
 V1.12.x - Added versioning of Sharepoint Addin App Manifest
 V1.13.x - Added support for SQL2016 and VS2017 to DacPac task
+V1.14.x - Filtered DacPac task to not version master or msdb DacPacs.
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of 


### PR DESCRIPTION
As noted in #111, some dacpac references were being built but not versioned. It shouldn't try to version master or msdb as part of this task and this will fix that.