### PR TITLE
Fixed up the line endings

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/agentSpecific.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/agentSpecific.ts
@@ -28,8 +28,8 @@ export function writeVariable (variableName : string ,value : string)
      if (variableName){
         logInfo(`Writing output variable ${variableName}`)
         // the newlines cause a problem only first line shown
-        // so remove them
-        var newlineRemoved = value.split("\n").join("  ");
+        // so replace them 
+        var newlineRemoved = value.replace(/\n/gi, '`n')
         tl.setVariable(variableName, newlineRemoved );
     }
 }


### PR DESCRIPTION
This now supports everything.  The variable now includes the full output (not just first line).  But also supports using the variable in email sending (maintaining line endings)