### PR TITLE
Added multiple artifact support + fixes a bunch of bugs

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/GenerateReleaseNotes.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/GenerateReleaseNotes.ts
@@ -1,5 +1,4 @@
 import tl = require("vsts-task-lib/task");
-import Q  = require("q");
 
 import { encodePat, 
          getRelease,

--- a/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/GenerateReleaseNotes.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/GenerateReleaseNotes.ts
@@ -1,4 +1,5 @@
 import tl = require("vsts-task-lib/task");
+import Q  = require("q");
 
 import { encodePat, 
          getRelease,
@@ -45,58 +46,79 @@ console.log(`Variable: Outputfile [${outputfile}]`);
 console.log(`Variable: OutputVariableName [${outputVariableName}]`);
 console.log(`Variable: OverrideStage [${overrideStage}]`);
 
-getRelease(instance, teamproject, encodedPat, currentReleaseId, function(details)
+// see if we are overriding the stage we are interested in?
+if (overrideStage === null)
 {
+    overrideStage = currentStage;
+}
 
-   // get the current release details first
-    var currentReleaseDetails = details;
-    getBuild(instance, teamproject, encodedPat, getPrimaryBuildIdFromRelease(currentReleaseDetails), function(details)
+
+
+async function run() {
+
+    var template = getTemplate(templateLocation,templateFile,inlineTemplate);
+    var globalWorkitems = [];
+    var globalCommits = [];
+
+    var currentReleaseDetails = await getRelease(instance, teamproject, encodedPat, currentReleaseId);
+
+    var pastSuccessfulRelease = await getPastSuccessfulRelease(instance, teamproject, encodedPat, currentReleaseDetails, overrideStage);
+
+    console.log(`Found ${currentReleaseDetails.artifacts.length + 1} artifacts in this release`)
+    for (let artifact of currentReleaseDetails.artifacts)
     {
-        var currentBuildDetails =  details;
+        console.log(`Looking at artifact [${artifact.alias}]`)
+        console.log(`Getting build associated with artifact. Build Id [${artifact.definitionReference.version.id}]`)
 
-        // see if we are overriding the stage we are interested in?
-        if (overrideStage === null)
-        {
-            overrideStage = currentStage;
+        var currentReleaseBuild = await getBuild(instance, teamproject, encodedPat, artifact.definitionReference.version.id)
+
+        console.log(`Looking for a matching artifact in the last successful release to ${overrideStage}`)
+        // Get the build from the past successful release
+        var pastSuccessfulMatchingArtifact = pastSuccessfulRelease.artifacts.find(item => item.definitionReference.definition.id == artifact.definitionReference.definition.id);
+
+        if (pastSuccessfulMatchingArtifact != null){
+            console.log(`Located matching artifact. Alias: ${pastSuccessfulMatchingArtifact.alias}.`)
+
+            // We have a matching build
+            var pastSuccessfulMatchingBuild = await getBuild(instance, teamproject, encodedPat, pastSuccessfulMatchingArtifact.definitionReference.version.id)
+
+            console.log(`Getting work items between release [${currentReleaseId}] and [${pastSuccessfulRelease.id}]`)
+
+            var workItems = await getWorkItemBetweenReleases(instance, teamproject, encodedPat, currentReleaseId, pastSuccessfulRelease.id)
+            var ids = [];
+                if (workItems){
+                // get list of work item ids
+                ids = workItems.map(w => w.id);
+            }
+
+            console.log(`Work items found: ${ids.length}`)
+
+            // and expand the details
+            var workItemDetails = await getWorkItems(instance, encodedPat, ids.join())
+
+            console.log(`Getting commits between [${currentReleaseBuild.sourceVersion}] and [${pastSuccessfulMatchingBuild.sourceVersion}].`)
+            var commits:Array<any> = await getCommitsBetweenCommitIds(
+                instance, 
+                teamproject, 
+                encodedPat, 
+                currentReleaseBuild.repository.type,
+                currentReleaseBuild.definition.id, 
+                currentReleaseBuild.repository.id, 
+                currentReleaseBuild.sourceVersion, 
+                pastSuccessfulMatchingBuild.sourceVersion);
+
+            console.log(`Commits found: ${commits.length}`)
+            globalWorkitems = globalWorkitems.concat(workItemDetails)
+            globalCommits = globalCommits.concat(commits)
+
         }
-        
-        getPastSuccessfulRelease(instance, teamproject, encodedPat, currentReleaseDetails, overrideStage,  function(details)
-        {
-            var compareReleaseDetails = details;
-            getBuild(instance, teamproject, encodedPat, getPrimaryBuildIdFromRelease(compareReleaseDetails), function(details)
-            {
-                var compareBuildDetails =  details;
-         
-                getWorkItemBetweenReleases(instance, teamproject, encodedPat, currentReleaseId, compareReleaseDetails.id, function (workItems)
-                {
-                    // get list of work item ids
-                    var ids = workItems.map(w => w.id);
-                    // and expand the details
-                    getWorkItems(instance, encodedPat, ids.join(), function (details)
-                    {
-                        var workItems = details;
 
-                        getCommitsBetweenCommitIds (
-                            instance, 
-                            teamproject, 
-                            encodedPat, 
-                            currentBuildDetails.repository.type,
-                            currentBuildDetails.definition.id, 
-                            currentBuildDetails.repository.id, 
-                            currentBuildDetails.sourceVersion, 
-                            compareBuildDetails.sourceVersion, function (commits)
-                        {
-                            var template = getTemplate(templateLocation,templateFile,inlineTemplate);
+    };
+    console.log(`Total commits found: ${globalCommits.length}`)
+    console.log(`Total workitems found: ${globalWorkitems.length}`)
+    var outputString = processTemplate(template, globalWorkitems, globalCommits, currentReleaseDetails, pastSuccessfulRelease, emptyDataset);
+    writeFile(outputfile, outputString);
+    writeVariable(outputVariableName,outputString.toString());
+};
 
-                            var outputString = processTemplate(template, workItems, commits, currentReleaseDetails, compareReleaseDetails, emptyDataset);
-                            writeFile(outputfile, outputString);
-                            writeVariable(outputVariableName,outputString.toString());
-                           
-                        });    
-                    });
-                });
-            });
-        });
-    });
-});
-
+run()

--- a/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/agentSpecific.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/agentSpecific.ts
@@ -29,7 +29,8 @@ export function writeVariable (variableName : string ,value : string)
         logInfo(`Writing output variable ${variableName}`)
         // the newlines cause a problem only first line shown
         // so remove them
-        var newlineRemoved = value.split("\n").join("  ");
+        //var newlineRemoved = value.split("\n").join("  ");
+        var newlineRemoved = value.replace(/\n/gi, '`n')
         tl.setVariable(variableName, newlineRemoved );
     }
 }


### PR DESCRIPTION
Sorry about the large PR.  I'll try and document below.

**New Features**
- Added support for multiple artifacts.  Previously the plugin seemed to only deal with the primary build.  Work Items and commits are pulled in for all artifacts now.

**Fundamental Changes**
- I really struggled to add the multiple artifact support using the callback architecture.  I swapped it out for async/await.  
- Added a bunch more logging
- Converted code to be async/await compatible (eg. remove forEach)

**Fixes**
- TFVC changesets were not being pulled through because the changesets were prefixed with "C"
- TFVC changesets were being limited to 100.  I have changed this limit to 1000. 
- TFVC changeset comments were truncated.
- Line endings were not working correct when trying to use the output variable in an email.
- If a checkin comment contained a line ending, this would break the plugin.
- Fixed an issue where the extension would crash if no workitems were returned.
