### PR TITLE
Fix (Generate Release Notes): Undefined $releasedefid for TFS 2015

### DIFF
--- a/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.ps1
+++ b/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.ps1
@@ -75,6 +75,12 @@ $releasedefname = $env:RELEASE_DEFINITIONNAME
 $buildnumber = $env:BUILD_BUILDNUMBER
 $currentStageName = $env:RELEASE_ENVIRONMENTNAME
 
+if ( [string]::IsNullOrEmpty($releasedefid) )
+{
+  $releasedefinition = Get-ReleaseDefinitionByName -tfsUri $collectionUrl -teamproject $teamproject -releasename $releasedefname -usedefaultcreds $usedefaultcreds
+
+  $releasedefid = $releasedefinition.id
+}
 
 Write-Verbose "collectionUrl = [$collectionUrl]"
 Write-Verbose "teamproject = [$teamproject]"

--- a/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.psm1
+++ b/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.psm1
@@ -114,6 +114,22 @@ function Get-BuildsByDefinitionId
   	$jsondata.value
 }
 
+function Get-ReleaseDefinitionByName
+{
+  param
+	  (
+    $tfsUri,
+    $teamproject,
+    $releasename,
+    $usedefaultcreds  
+	  )
+  
+  $uri = "$($tfsUri)/$($teamproject)/_apis/release/definitions?api-version=3.0-preview.1"
+  $jsondata = Invoke-GetCommand -uri $uri -usedefaultcreds $usedefaultcreds | ConvertFrom-Json
+  $jsondata.value | where { $_.name -eq $releasename  }
+
+}
+
 function Get-Release
 {
 


### PR DESCRIPTION
Since ```$releasedefid``` is unsupported for TFS 2015, I lookup the release definition id by the name. There is the risk that the release definition names could be the same across different release definition ids.