### PR TITLE
error trapping and returning correct status

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/GenerateReleaseNotes.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/GenerateReleaseNotes.ts
@@ -121,11 +121,12 @@ async function run() {
         var outputString = processTemplate(template, globalWorkitems, globalCommits, currentReleaseDetails, pastSuccessfulRelease, emptyDataset);
         writeFile(outputfile, outputString);
         writeVariable(outputVariableName,outputString.toString());
+        tl.setResult(tl.TaskResult.Succeeded, "Generate Release Notes Task Succeeded");
     }
     catch(err)
     {
         tl.error(err.message);
-        tl.setResult(tl.TaskResult.Failed, tl.loc('GenerateReleaseNotesFailed', err.message));
+        tl.setResult(tl.TaskResult.Failed, "Generate Release Notes Task failed: " + err.message);
     }
 };
 

--- a/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XPlatGenerateReleaseNotesTask.src/ReleaseNotesFunctions.ts
@@ -356,11 +356,11 @@ export function processTemplate(template, workItems, commits, releaseDetails, co
                       // reset the index to process the block
                       index = modeStack[modeStack.length-1].Index
                       switch (mode)
-			                {
-			                    case Mode.WI :
-                              logDebug (`${addSpace(modeStack.length +1)} Getting next workitem ${item.id}`)
+                      {
+                            case Mode.WI :
+                                  logDebug (`${addSpace(modeStack.length +1)} Getting next workitem ${item.id}`)
 		                          widetail = item ;  
-                              break;
+                            break;
                           case Mode.CS :
                              if (csdetail.commitId)
                              {


### PR DESCRIPTION
Fixes

- Errors were being swallowed and task was being marked as successful even when errors were occuring.
- If there were no workitems returned, this would cause an error.