### PR TITLE
VersionNuspecTask: Change to find nuspec files in the root - Fixes #143

### DIFF
--- a/Extensions/Versioning/VersionNuspecTask/ApplyVersionToNuspec.ps1
+++ b/Extensions/Versioning/VersionNuspecTask/ApplyVersionToNuspec.ps1
@@ -15,12 +15,19 @@
 param (
 
     [Parameter(Mandatory)]
+    [ValidateScript({
+        If (-not (Test-Path -Path $_)) {
+            throw 'Invalid path specified'
+        }
+        $True
+    })]
     [String]$Path,
 
     [Parameter(Mandatory)]
     [string]$VersionNumber,
 
-    $VersionRegex,
+    [ValidateNotNullOrEmpty()]
+    [string]$VersionRegex,
 
     $outputversion
 )
@@ -28,12 +35,6 @@ param (
 # Set a flag to force verbose as a default
 $VerbosePreference ='Continue' # equiv to -verbose
 
-# Make sure path to source code directory is available
-if (-not (Test-Path $Path))
-{
-    Write-Error "Source directory does not exist: $Path"
-    exit 1
-}
 Write-Verbose "Source Directory: $Path"
 Write-Verbose "Version Number/Build Number: $VersionNumber"
 Write-Verbose "Version Filter: $VersionRegex"
@@ -59,9 +60,7 @@ $NewVersion = $VersionData[0]
 Write-Verbose "Version: $NewVersion"
 
 # Apply the version to the assembly property files
-$files = gci $Path -recurse | 
-    ?{ $_.PSIsContainer } | 
-    foreach { gci -Path $_.FullName -Recurse -include *.nuspec }
+$files = Get-ChildItem -Path $Path -Recurse -Include *.nuspec
 if($files)
 {
     Write-Verbose "Will apply $NewVersion to $($files.count) files."

--- a/Extensions/Versioning/VersionNuspecTask/task.json
+++ b/Extensions/Versioning/VersionNuspecTask/task.json
@@ -12,7 +12,7 @@
   "author": "Black Marble",
   "version": {
     "Major": 1,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
    "groups": [

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -17,6 +17,7 @@ V1.14.x - DAC pack exclusing fixed
 V1.15.x - Added cross platform support for assebmly versioning
           Added WIX versioning
 V1.16   - Fixed bug on .NETcore versioning
+V1.17   - Fixed bug with nuspec versioning that was not finding files in the root path.
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of 

--- a/Tests/Extensions/Versioning/VersionNuspecTask/ApplyVersionToNuspec.Tests.ps1
+++ b/Tests/Extensions/Versioning/VersionNuspecTask/ApplyVersionToNuspec.Tests.ps1
@@ -1,0 +1,64 @@
+$sut = "$PSScriptRoot\..\..\..\..\extensions\versioning\VersionNuspecTask\ApplyVersionToNuspec.ps1" 
+
+Describe 'Testing Nuspec Versioning Task' {
+
+    Mock -CommandName Write-Verbose -MockWith {}
+    Mock -CommandName Write-Warning -MockWith {}
+    Mock -CommandName Write-host -MockWith {}
+
+    Context 'Testing input' {
+        it 'Should have Path as a mandatory parameter' {
+            (Get-Command $sut).Parameters['Path'].Attributes.Mandatory | Should Be $True
+        }
+
+        It 'Should throw is given an invalid Path' {
+            {&$Sut -Path TestDrive:\Some\Files\Here -VersionNumber '1.2.3.4'} | Should Throw
+        }
+
+        It 'Should have version number as a mandartory parameter' {
+            (Get-Command $sut).Parameters['VersionNumber'].Attributes.Mandatory | Should Be $True
+        }
+
+        It 'Should throw if given an empty or null version regex' {
+            {&$Sut -Path TestDrive:\ -VersionNumber '1.2.3.4' -VersionRegex ''} | Should Throw
+            {&$Sut -Path TestDrive:\ -VersionNumber '1.2.3.4' -VersionRegex $null} | Should Throw
+        }
+    }
+
+    Context 'Testing processing' {
+        $XmlExample = @"
+            <package>
+            <metadata>
+            <version>5.6.7.8</version>
+            </metadata>
+            </package>
+"@
+        New-Item -Path TestDrive:\ -Name Example.nuspec -ItemType File -Value $XmlExample
+        New-Item -Path TestDrive:\ -Name SubFolder -ItemType Directory
+        New-Item -Path TestDrive:\SubFolder -Name OtherFile.nuspec -ItemType File -Value $XmlExample
+
+        it 'should attempt to edit all files found' {
+            &$Sut -Path TestDrive:\ -VersionNumber '1.2.3.4' -VersionRegex '\d.\d.\d.\d'
+
+            (Get-Content -Path TestDrive:\Example.nuspec -raw) -ne $XmlExample | Should be $true
+            (Get-Content -Path TestDrive:\Subfolder\Otherfile.nuspec -raw) -ne $XmlExample | Should be $true
+        }
+
+        it 'should write a warning if no files found' {
+            Mock -CommandName Get-ChildItem -MockWith {}
+            &$Sut -Path TestDrive:\ -VersionNumber '1.2.3.4' -VersionRegex '\d.\d.\d.\d'
+
+            Assert-MockCalled -CommandName Write-Warning -Times 1 -Exactly -Scope It
+        }
+
+        it 'should call all mocks' {
+            Mock -CommandName Get-ChildItem -MockWith {@(1,2)}
+            Mock -CommandName Get-Content -MockWith {$XmlExample}
+            
+            {&$Sut -Path TestDrive:\ -VersionNumber '1.2.3.4'} | Should Not Throw
+            Assert-MockCalled -CommandName Get-ChildItem -Times 1
+            Assert-MockCalled -CommandName Get-Content -Times 2
+        }
+
+    }
+}


### PR DESCRIPTION
Changed the Get-ChildItem filter so it looks in the root folder and everything under it for nuspec files rather than the previous method of finding all folders and then checking within those for nuspec files.

I've also added a bunch of tests but they probably need some more work.