### PR TITLE
Move versioning tests into central location

### DIFF
--- a/Tests/Extensions/Versioning/VersionDacpacTask/Get-Toolpath.tests.ps1
+++ b/Tests/Extensions/Versioning/VersionDacpacTask/Get-Toolpath.tests.ps1
@@ -1,7 +1,8 @@
 # Load the script under test
-. "$PSScriptRoot\..\..\..\extensions\versioning\versiondacpactask\Update-DacPacVersionNumber.ps1" 
+. "$PSScriptRoot\..\..\..\..\extensions\versioning\versiondacpactask\Update-DacPacVersionNumber.ps1" 
 
 Describe "Use VS2013 SQL2012 120 ToolPath settings" {
+    Mock -CommandName Write-Verbose -MockWith {}
     Mock Test-Path  {return $false} -ParameterFilter { 
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
@@ -22,6 +23,7 @@ Describe "Use VS2013 SQL2012 120 ToolPath settings" {
 }
 
 Describe "Use VS2015 SQL2014 120 ToolPath settings" {
+    Mock -CommandName Write-Verbose -MockWith {}
    Mock Test-Path  {return $false} -ParameterFilter { 
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
@@ -39,6 +41,7 @@ Describe "Use VS2015 SQL2014 120 ToolPath settings" {
 }
 
 Describe "Use VS2015 SQL2014 130 ToolPath settings" {
+    Mock -CommandName Write-Verbose -MockWith {}
    Mock Test-Path  {return $false} -ParameterFilter { 
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
@@ -53,6 +56,7 @@ Describe "Use VS2015 SQL2014 130 ToolPath settings" {
 }
 
 Describe "Use VS2017 SQL2014 130 ToolPath settings" {
+    Mock -CommandName Write-Verbose -MockWith {}
    Mock Test-Path  {return $true} -ParameterFilter { 
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
@@ -71,6 +75,7 @@ Describe "Use VS2017 SQL2014 130 ToolPath settings" {
 
 
 Describe "Use User ToolPath settings" {
+    Mock -CommandName Write-Verbose -MockWith {}
     Mock Test-Path  {return $false} -ParameterFilter { 
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Microsoft.SqlServer.Dac.Extensions.dll"
         } 
@@ -91,6 +96,7 @@ Describe "Use User ToolPath settings" {
 
 
 Describe "Cannot use User ToolPath settings" {
+    Mock -CommandName Write-Verbose -MockWith {}
     Mock Test-Path  {return $false}
     Mock write-error -MockWith {return $msg -match "Mocked error"} -verifiable
 


### PR DESCRIPTION
Moved the VersionDacpacTask tests into a general Versioning folder. Also added a bit more mocking to tidy up the output from those tests.