### PR TITLE
Run32Bit not finding correct module path - Fixes #150

### DIFF
--- a/Extensions/Pester/PesterTask/Pester.ps1
+++ b/Extensions/Pester/PesterTask/Pester.ps1
@@ -53,7 +53,7 @@ if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86")
 {
     # Get the command parameters
     $args = $myinvocation.BoundParameters.GetEnumerator() | ForEach-Object { 
-        if ([string]::IsNullOrWhiteSpace($_.Value)) 
+        if (-not([string]::IsNullOrWhiteSpace($_.Value)))
         {
             If ($_.Value -eq 'True' -and $_.Key -ne 'run32Bit') 
             {

--- a/Extensions/Pester/PesterTask/Pester.ps1
+++ b/Extensions/Pester/PesterTask/Pester.ps1
@@ -70,7 +70,7 @@ write-verbose "Running in $($env:Processor_Architecture) PowerShell" -verbose
 if ([string]::IsNullOrEmpty($moduleFolder) -and (-not(Get-Module -ListAvailable Pester)))
 {
     # we have no module path specified so use the copy we have in this task
-    $moduleFolder = "$PSScriptRoot\$pesterVersion"
+    $moduleFolder = "$pwd\$pesterVersion"
     Write-Verbose "Loading Pester module from [$moduleFolder]" -verbose
     Import-Module $moduleFolder\Pester.psd1 
 }

--- a/Extensions/Pester/PesterTask/Pester.ps1
+++ b/Extensions/Pester/PesterTask/Pester.ps1
@@ -77,7 +77,7 @@ if ([string]::IsNullOrEmpty($moduleFolder) -and (-not(Get-Module -ListAvailable 
     # we have no module path specified so use the copy we have in this task
     $moduleFolder = "$pwd\$pesterVersion"
     Write-Verbose "Loading Pester module from [$moduleFolder]" -verbose
-    Import-Module $moduleFolder\Pester.psd1 
+    Import-Module $moduleFolder\Pester.psd1
 }
 elseif ($moduleFolder)
 {

--- a/Extensions/Pester/PesterTask/Pester.ps1
+++ b/Extensions/Pester/PesterTask/Pester.ps1
@@ -53,12 +53,17 @@ if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86")
 {
     # Get the command parameters
     $args = $myinvocation.BoundParameters.GetEnumerator() | ForEach-Object { 
-        If ($_.Value -eq 'True' -and $_.Key -ne 'run32Bit') {
-            "-$($_.Key)"
-        }
-        else {
-            "-$($_.Key)"
-            "$($_.Value)"
+        if ([string]::IsNullOrWhiteSpace($_.Value)) 
+        {
+            If ($_.Value -eq 'True' -and $_.Key -ne 'run32Bit') 
+            {
+                "-$($_.Key)"
+            }
+            else 
+            {
+                "-$($_.Key)"
+                "$($_.Value)"
+            }
         }
     }
     write-warning 'Re-launching in x86 PowerShell'

--- a/Extensions/Pester/PesterTask/Pester.ps1
+++ b/Extensions/Pester/PesterTask/Pester.ps1
@@ -52,7 +52,15 @@ param
 if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86")   
 {
     # Get the command parameters
-    $args = $myinvocation.BoundParameters.GetEnumerator() | ForEach-Object {$($_.Value)}
+    $args = $myinvocation.BoundParameters.GetEnumerator() | ForEach-Object { 
+        If ($_.Value -eq 'True' -and $_.Key -ne 'run32Bit') {
+            "-$($_.Key)"
+        }
+        else {
+            "-$($_.Key)"
+            "$($_.Value)"
+        }
+    }
     write-warning 'Re-launching in x86 PowerShell'
     &"$env:windir\syswow64\windowspowershell\v1.0\powershell.exe" -noprofile -executionpolicy bypass -file $myinvocation.Mycommand.path $args
     exit
@@ -62,9 +70,9 @@ write-verbose "Running in $($env:Processor_Architecture) PowerShell" -verbose
 if ([string]::IsNullOrEmpty($moduleFolder) -and (-not(Get-Module -ListAvailable Pester)))
 {
     # we have no module path specified so use the copy we have in this task
-    $moduleFolder = "$pwd\$pesterVersion"
+    $moduleFolder = "$PSScriptRoot\$pesterVersion"
     Write-Verbose "Loading Pester module from [$moduleFolder]" -verbose
-    Import-Module $moduleFolder\Pester.psd1
+    Import-Module $moduleFolder\Pester.psd1 
 }
 elseif ($moduleFolder)
 {


### PR DESCRIPTION
The method of building the arguments for the x86 process appeared to be populating the $ModuleFolder variable when it shouldn't have. This modifies it to build it like a normal parameter string.