### PR TITLE
StyleCopTask: Adding allowable violations count

### DIFF
--- a/Extensions/StyleCop/StyleCopTask/StyleCop.ps1
+++ b/Extensions/StyleCop/StyleCopTask/StyleCop.ps1
@@ -2,7 +2,7 @@ param
 (
     [string]$treatStyleCopViolationsErrorsAsWarnings,
     [string]$maximumViolationCount,
-	[string]$allowableViolationCount,
+    [string]$allowableViolationCount,
     [string]$showOutput,
     [string]$cacheResults,
     [string]$forceFullAnalysis,

--- a/Extensions/StyleCop/StyleCopTask/StyleCop.ps1
+++ b/Extensions/StyleCop/StyleCopTask/StyleCop.ps1
@@ -2,6 +2,7 @@ param
 (
     [string]$treatStyleCopViolationsErrorsAsWarnings,
     [string]$maximumViolationCount,
+	[string]$allowableViolationCount,
     [string]$showOutput,
     [string]$cacheResults,
     [string]$forceFullAnalysis,
@@ -46,11 +47,23 @@ Add-Content $summaryMdPath ("`nStyleCop found [{0}] violations across [{1}] proj
 Write-verbose "Uploading summary results file"
 Write-Host "##vso[build.uploadsummary]$summaryMdPath"
 
+# Set the message that will be returned
 if ($result.OverallSuccess -eq $false)
 {
-   Write-Error ("StyleCop found [{0}] violations across [{1}] projects" -f $result.TotalViolations, $result.ProjectsScanned)
+   $resultMessage = ("StyleCop found [{0}] violations across [{1}] projects" -f $result.TotalViolations, $result.ProjectsScanned)
 } 
 else
 {
-   Write-Verbose ("StyleCop found [{0}] violations warnings across [{1}] projects" -f $result.TotalViolations, $result.ProjectsScanned)
+   $resultMessage = ("StyleCop found [{0}] violations warnings across [{1}] projects" -f $result.TotalViolations, $result.ProjectsScanned)
 }
+
+# Determine if the task should error
+if ([int]$result.TotalViolations -gt [int]$allowableViolationCount)
+{
+   Write-Error ($resultMessage)
+} 
+else
+{
+   Write-Verbose ($resultMessage)
+}
+

--- a/Extensions/StyleCop/StyleCopTask/task.json
+++ b/Extensions/StyleCop/StyleCopTask/task.json
@@ -3,11 +3,11 @@
   "name": "StyleCop",
   "friendlyName": "StyleCop Runner by Black Marble",
   "description": "Black Marble's StyleCop test runner that use settings files in the project folders. (Using StyleCop 4.7.59.0)",
- "helpMarkDown": "Version: #{Build.BuildNumber}#. [More Information](https://github.com/rfennell/vNextBuild/wiki/StyleCop-Runner-Task/)",
+  "helpMarkDown": "Version: #{Build.BuildNumber}#. [More Information](https://github.com/rfennell/vNextBuild/wiki/StyleCop-Runner-Task/)",
   "category": "Build",
   "visibility": [
-                "Build"
-                ],
+    "Build"
+  ],
   "author": "Black Marble",
   "version": {
     "Major": 1,
@@ -48,8 +48,18 @@
       "label": "Max. Violation Count",
       "defaultValue": "1000",
       "required": true,
-      "helpMarkDown": "Maximum violations before analysis stops",
+      "helpMarkDown": "Maximum project violations before analysis stops",
       "groupName":"advanced"
+    }
+    ,
+    {
+      "name": "allowableViolationCount",
+      "type": "string",
+      "label": "Allowable Violation Count",
+      "defaultValue": "0",
+      "required": true,
+      "helpMarkDown": "Number of violations allowed before the task fails",
+      "groupName": "advanced"
     }
     ,
     {

--- a/Extensions/StyleCop/StyleCopTask/task.json
+++ b/Extensions/StyleCop/StyleCopTask/task.json
@@ -50,8 +50,7 @@
       "required": true,
       "helpMarkDown": "Maximum project violations before analysis stops",
       "groupName":"advanced"
-    }
-    ,
+    },
     {
       "name": "allowableViolationCount",
       "type": "string",
@@ -60,8 +59,7 @@
       "required": true,
       "helpMarkDown": "Number of violations allowed before the task fails",
       "groupName": "advanced"
-    }
-    ,
+    },
     {
       "name": "showOutput",
       "type": "boolean",
@@ -70,8 +68,7 @@
       "required": true,
       "helpMarkDown": "Show analysis output in log",
       "groupName":"advanced"
-    }
-    ,
+    },
     {
       "name": "cacheResults",
       "type": "boolean",
@@ -80,8 +77,7 @@
       "required": true,
       "helpMarkDown": "Cache analysis results for reuse",
       "groupName":"advanced"
-    }
-    ,
+    },
     {
       "name": "forceFullAnalysis",
       "type": "boolean",
@@ -90,8 +86,7 @@
       "required": true,
       "helpMarkDown": "Force complete re-analysis (ignores any cached results)",
       "groupName":"advanced"
-    }
-    ,
+    },
     {
       "name": "additionalAddInPath",
       "type": "filePath",
@@ -100,8 +95,7 @@
       "required": false,
       "helpMarkDown": "Path to any custom rulesets, the directory should not be a sub directory of the current directory at runtime as this is automatically scanned",
       "groupName":"advanced"
-    }
-    ,
+    },
     {
       "name": "settingsFile",
       "type": "filePath",
@@ -111,7 +105,7 @@
       "helpMarkDown": "Path to single settings files to use (as opposed to files in project folders)",
       "groupName":"advanced"
     },
-     {
+    {
       "name": "loggingfolder",
       "type": "string",
       "label": "Logging Folder",
@@ -119,9 +113,8 @@
       "required": true,
       "helpMarkDown": "Folder to place the detailed text and XML formated log files",
       "groupName":"advanced"
-    }
-    ,
-     {
+    },
+    {
       "name": "summaryFileName",
       "type": "string",
       "label": "Summary File Name",


### PR DESCRIPTION
As we all know the first step in managing technical debt is stopping the rot. With that in mind, I've had a stab at adding an 'Allowable Violation Count' to the Task for StyleCop. The idea is that you can set a threshold which if you have fewer violations than the task doesn't error.

I'm afraid this is a new foray into PS and these tasks for me, so the change might be off but hopefully, it's helpful.