### PR TITLE
Fix "Test Errors as Warnings" flag being ignored

### DIFF
--- a/Extensions/StyleCop/StyleCopTask/StyleCop.ps1
+++ b/Extensions/StyleCop/StyleCopTask/StyleCop.ps1
@@ -58,7 +58,7 @@ else
 }
 
 # Determine if the task should error
-if ([int]$result.TotalViolations -gt [int]$allowableViolationCount)
+if ($result.OverallSuccess -eq $false -and [int]$result.TotalViolations -gt [int]$allowableViolationCount)
 {
    Write-Error ($resultMessage)
 } 


### PR DESCRIPTION
Sorry, my previous PR broke this and just I noticed it on one of my builds. While I was using OverallSuccess to control the content of the message I wasn't evaluating it to decide if the task should error or not. This resulted in the build erroring if the flag was set and the there were violations.