### PR TITLE
Update to use api version 4 when updating build variables -Fixes #168

### DIFF
--- a/Extensions/BuildUpdating/BuildVariableTask/BuildVariableTask.ps1
+++ b/Extensions/BuildUpdating/BuildVariableTask/BuildVariableTask.ps1
@@ -5,7 +5,7 @@ param
     $mode,
     $value,
     $usedefaultcreds
- 
+
  )
 
 
@@ -22,15 +22,15 @@ function Set-BuildDefinationVariable
     )
 
     $webclient = Get-WebClient -usedefaultcreds $usedefaultcreds
-    
+
     write-verbose "Updating Build Definition $builddefID for $($tfsUri)/$($teamproject)"
 
-    $uri = "$($tfsUri)/$($teamproject)/_apis/build/definitions/$($buildDefID)?api-version=2.0"
+    $uri = "$($tfsUri)/$($teamproject)/_apis/build/definitions/$($buildDefID)?api-version=4.0"
     $jsondata = $data | ConvertTo-Json -Compress -Depth 10 #else we don't get lower level items
 
-    $response = $webclient.UploadString($uri,"PUT", $jsondata) 
+    $response = $webclient.UploadString($uri,"PUT", $jsondata)
     $response
-    
+
 }
 
 function Get-WebClient
@@ -41,7 +41,7 @@ function Get-WebClient
     )
 
     $webclient = new-object System.Net.WebClient
-	
+
     if ([System.Convert]::ToBoolean($usedefaultcreds) -eq $true)
     {
         Write-Verbose "Using default credentials"
@@ -71,14 +71,14 @@ function Get-BuildDefination
     )
 
     $webclient = Get-WebClient -usedefaultcreds $usedefaultcreds
-   
+
     write-verbose "Getting Build Definition $builddefID "
 
-    $uri = "$($tfsUri)/$($teamproject)/_apis/build/definitions/$($buildDefID)?api-version=2.0"
+    $uri = "$($tfsUri)/$($teamproject)/_apis/build/definitions/$($buildDefID)?api-version=4.0"
 
-    $response = $webclient.DownloadString($uri) | ConvertFrom-Json 
+    $response = $webclient.DownloadString($uri) | ConvertFrom-Json
     $response
-    
+
 }
 
 
@@ -102,7 +102,7 @@ function Update-Build
     {
         Write-Verbose "Manually updating variable"
         $def.variables.$variable.value = "$value"
-    } else 
+    } else
     {
         Write-Verbose "Autoincrementing variable"
         $def.variables.$variable.value = "$([convert]::ToInt32($def.variables.$variable.value) +1)"
@@ -124,10 +124,10 @@ function Get-BuildsDefsForRelease
     )
 
     $webclient = Get-WebClient -usedefaultcreds $usedefaultcreds
-    
+
     write-verbose "Getting Builds for Release releaseID"
 
-    # at present Jun 2016 this API is in preview and in different places in VSTS hence this fix up   
+    # at present Jun 2016 this API is in preview and in different places in VSTS hence this fix up
 	$rmtfsUri = $tfsUri -replace ".visualstudio.com",  ".vsrm.visualstudio.com/defaultcollection"
     $uri = "$($rmtfsUri)/$($teamproject)/_apis/release/releases/$($releaseId)?api-version=3.0-preview"
     $response = $webclient.DownloadString($uri)
@@ -158,9 +158,9 @@ function Get-Build
     write-verbose "Getting BuildDef for Build"
 
     $webclient = Get-WebClient -usedefaultcreds $usedefaultcreds
-    $uri = "$($tfsUri)/$($teamproject)/_apis/build/builds/$($buildid)?api-version=2.0"
+    $uri = "$($tfsUri)/$($teamproject)/_apis/build/builds/$($buildid)?api-version=4.0"
     $jsondata = $webclient.DownloadString($uri) | ConvertFrom-Json
-    $jsondata 
+    $jsondata
 }
 
 # Output execution parameters.
@@ -184,10 +184,10 @@ if ( [string]::IsNullOrEmpty($releaseid))
 {
     Write-Verbose "Running inside a build so updating current build $buildid"
     $build = Get-Build -tfsuri $collectionUrl -teamproject $teamproject -buildid $buildid -usedefaultcreds $usedefaultcreds
-    
+
     $builddefid = $build.definition.id
     Write-Verbose "Build has definition id of $builddefid"
- 
+
     Update-Build -tfsuri $collectionUrl -teamproject $teamproject -builddefid $builddefid -mode $mode -value $value -variable $variable -usedefaultcreds $usedefaultcreds
 
 } else {
@@ -201,7 +201,7 @@ if ( [string]::IsNullOrEmpty($releaseid))
         {
             Update-Build -tfsuri $collectionUrl -teamproject $teamproject -builddefid $id -mode $mode -value $value -variable $variable -usedefaultcreds $usedefaultcreds
         }
-    } else 
+    } else
     {
         Update-Build -tfsuri $collectionUrl -teamproject $teamproject -builddefid $builddefid -mode $mode -value $value -variable $variable -usedefaultcreds $usedefaultcreds
     }

--- a/Extensions/BuildUpdating/readme.md
+++ b/Extensions/BuildUpdating/readme.md
@@ -5,6 +5,7 @@
 - 1.3.x - Fixed bug with handling of defaultcreds
 - 1.4.x - Include PR from insanity13 to handle compress
 - 1.5.x - Allow the build variable updater to be used in a build as well as a release
+- 1.6.x - Update to newer api version to support variable groups and more ([issue #168](https://github.com/rfennell/vNextBuild/issues/168))
 
 A set of tasks to manage builds, it is assumed these tasks will usually be called from a release pipeline.
 
@@ -14,16 +15,16 @@ This task sets the 'keep forever' retension flag on a build. It takes one parame
 
 * Select only the primary build associated with the release (default)
 * All the build artifacts associated with the release
-* (Advanced) Use use build agents default credentials as opposed to agent token - usually only every needed for TFS usage 
+* (Advanced) Use use build agents default credentials as opposed to agent token - usually only every needed for TFS usage
 
 ### Update Build Variable Task
-This task allows a variable to be set in a build definition. 
+This task allows a variable to be set in a build definition.
 
 The prime use of this task is envisaged to be the updating of a variable that specifies a version number that needs to be incremented when a release to production occurs.
 
 It uses the following parameters
 
-* Build selection mode 
+* Build selection mode
     * Only the primary build associated with the release (default)
     * All the build artifacts associated with the release
 * Variable name to update
@@ -31,12 +32,12 @@ It uses the following parameters
     * Auto-increment the variable (default)
     * Specify a value
 * Value if not set to auto-increment
-* (Advanced) Use use build agents default credentials as opposed to agent token - usually only every needed for TFS usage 
+* (Advanced) Use use build agents default credentials as opposed to agent token - usually only every needed for TFS usage
 
 **Important**: The default rights of a build agent running a release is to not have the permission to edit the build definition. If this task is used without altering these permission you will get a 403 error
 
-  
-> Exception calling "UploadString" with "3" argument(s): "The remote server returned an error: (403) Forbidden." 
+
+> Exception calling "UploadString" with "3" argument(s): "The remote server returned an error: (403) Forbidden."
 
 
 To address this problem


### PR DESCRIPTION
As raised in #168 there is a problem with updating build variables using the old api versions as it removes the variable groups and other features that have been added. 

Changes appear to be more than actually needed as vscode decided to tidy up the style a little with trailing spaces etc being removed.