### PR TITLE
Fix .Net Core versioning with targeting multiple frameworks. -Fixes #166 #167

### DIFF
--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
@@ -42,27 +42,27 @@ if (!fs.existsSync(path))
 {
     tl.error(`Source directory does not exist: ${path}`);
     process.exit(1);
-} 
+}
 
 // Get and validate the version data
 var regexp = new RegExp(versionRegex);
 var versionData = regexp.exec(versionNumber);
 if (!versionData)
 {
-    // extra check as we don't get zero size array but a null 
+    // extra check as we don't get zero size array but a null
     tl.error(`Could not find version number data in ${versionNumber} that matches ${versionRegex}.`);
     process.exit(1);
 }
 switch(versionData.length)
 {
-   case 0:       
-         // this is trapped by the null check above 
+   case 0:
+         // this is trapped by the null check above
          tl.error(`Could not find version number data in ${versionNumber} that matches ${versionRegex}.`);
          process.exit(1);
    case 1:
         break;
-   default: 
-         tl.warning(`Found more than instance of version data in ${versionNumber}  that matches ${versionRegex}.`); 
+   default:
+         tl.warning(`Found more than instance of version data in ${versionNumber}  that matches ${versionRegex}.`);
          tl.warning(`Will assume first instance is version.`);
          break;
 }
@@ -71,7 +71,7 @@ var newVersion = versionData[0]
 console.log (`Extracted Version: ${newVersion}`);
 
 // Apply the version to the assembly property files
-var files = findFiles(`${path}`, filenamePattern, files); 
+var files = findFiles(`${path}`, filenamePattern, files);
 
 
 if (files.length>0) {
@@ -84,18 +84,31 @@ if (files.length>0) {
         var filecontent = fs.readFileSync(file, fileEncoding.encoding);
         fs.chmodSync(file,"600");
 
-         // Check that the field to update is present 
+         // Check that the field to update is present
         var tmpField = "AssemblyVersion";
         if (field && field.length > 0)
         {
             tmpField = field;
-        } 
-        
-        if (filecontent.toString().toLowerCase().indexOf(tmpField.toLowerCase()) === -1) { 
+        }
+
+        if (filecontent.toString().toLowerCase().indexOf(tmpField.toLowerCase()) === -1) {
             console.log (`The ${tmpField} version is not present in the .csproj file so adding it`);
             // add the field, trying to avoid having to load library to parse xml
-             var newVersionField = `</TargetFramework><${tmpField}>${newVersion}<\/${tmpField}>`;
-             fs.writeFileSync(file,filecontent.toString().replace(`</TargetFramework>`, newVersionField),fileEncoding.encoding);
+            // Check for TargetFramework when only using a single framework
+             regexp = new RegExp("</TargetFramework>","g")
+             if (regexp.exec(filecontent.toString()))
+             {
+                var newVersionField = `</TargetFramework><${tmpField}>${newVersion}<\/${tmpField}>`;
+                fs.writeFileSync(file,filecontent.toString().replace(`</TargetFramework>`, newVersionField),fileEncoding.encoding);
+             }
+             // Check for TargetFrameworks when using multiple frameworks
+             regexp = new RegExp("</TargetFrameworks>","g")
+             if (regexp.exec(filecontent.toString()))
+             {
+                var newVersionField = `</TargetFrameworks><${tmpField}>${newVersion}<\/${tmpField}>`;
+                fs.writeFileSync(file,filecontent.toString().replace(`</TargetFrameworks>`, newVersionField),fileEncoding.encoding);
+             }
+
         } else
         {
             if (field && field.length > 0)

--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
@@ -85,7 +85,7 @@ if (files.length>0) {
         fs.chmodSync(file,"600");
 
          // Check that the field to update is present
-        var tmpField = "AssemblyVersion";
+        var tmpField = "Version";
         if (field && field.length > 0)
         {
             tmpField = field;

--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
@@ -98,6 +98,7 @@ if (files.length>0) {
              regexp = new RegExp("</TargetFramework>","g")
              if (regexp.exec(filecontent.toString()))
              {
+                console.log (`The ${file} .csproj file only targets 1 framework`);
                 var newVersionField = `</TargetFramework><${tmpField}>${newVersion}<\/${tmpField}>`;
                 fs.writeFileSync(file,filecontent.toString().replace(`</TargetFramework>`, newVersionField),fileEncoding.encoding);
              }
@@ -105,6 +106,7 @@ if (files.length>0) {
              regexp = new RegExp("</TargetFrameworks>","g")
              if (regexp.exec(filecontent.toString()))
              {
+                console.log (`The ${file} .csproj file targets multiple frameworks`);
                 var newVersionField = `</TargetFrameworks><${tmpField}>${newVersion}<\/${tmpField}>`;
                 fs.writeFileSync(file,filecontent.toString().replace(`</TargetFrameworks>`, newVersionField),fileEncoding.encoding);
              }

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -20,6 +20,7 @@
 - V1.17   - Fixed bug with nuspec versioning that was not finding files in the root path.
 - V1.18   - Issue 129
 - V1.19   - Issue 160 with .NET Core and Standard Versioning
+- V1.22   - Fixed Issue 166 with .NET Core not versioning csproj files targetting multiple frameworks.
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of


### PR DESCRIPTION
Added some extra regex to check if the `</TargetFramework>` or `</TargetFrameworks>` is present use whichever is there (see #166).

Also added a fix for #167 by changing the default field used to Version rather than AssemblyVersion as Version also effects Product Version field in the final output.