### PR TITLE
Fix .Net Core versioning of all uses of version numbers - Fixes #183

### DIFF
--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
@@ -85,10 +85,10 @@ if (files.length>0) {
         fs.chmodSync(file,"600");
 
          // Check that the field to update is present
-        var tmpField = "Version";
+        var tmpField = "<Version>";
         if (field && field.length > 0)
         {
-            tmpField = field;
+            tmpField = `<${field}>`;
         }
 
         if (filecontent.toString().toLowerCase().indexOf(tmpField.toLowerCase()) === -1) {
@@ -96,6 +96,7 @@ if (files.length>0) {
             // add the field, trying to avoid having to load library to parse xml
             // Check for TargetFramework when only using a single framework
              regexp = new RegExp("</TargetFramework>","g")
+             tmpField = tmpField.replace('<','').replace('>','')
              if (regexp.exec(filecontent.toString()))
              {
                 console.log (`The ${file} .csproj file only targets 1 framework`);

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -22,6 +22,7 @@
 - V1.19   - Issue 160 with .NET Core and Standard Versioning
 - V1.22   - Fixed Issue 166 with .NET Core not versioning csproj files targetting multiple frameworks.
     - Fixed Issue 167 with .NET Core versioning not applying correctly to nupkg and product version fields.
+- V1.23   - Fixed Issue 183 which broke due to V1.22 changing default behaviour.
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of


### PR DESCRIPTION
Following the fixes in #182 it appears the regex broke the versioning so it always replaces all instances of the build number regex with the build number. This impacted nuget packages when using x.x.x version numbers.