### PR TITLE
Replicate esbenbach changes to catch if field was specified but version format differs - fixes #185

### DIFF
--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask.src/ApplyVersionToAssemblies.ts
@@ -117,9 +117,20 @@ if (files.length>0) {
             if (field && field.length > 0)
             {
                 console.log (`Updating only the ${field} version`);
-                regexp = new RegExp(`<${field}>${versionRegex}<\/${field}>`);
-                var newVersionField = `<${field}>${newVersion}<\/${field}>`;
-                fs.writeFileSync(file,filecontent.toString().replace(regexp, newVersionField),fileEncoding.encoding);
+                const csprojVersionRegex = `(<${field}>)(.*)(<\/${field}>)`;
+                var regexp = new RegExp(csprojVersionRegex,'gmi');
+                let content: string = filecontent.toString();
+                let matches;
+                while ((matches = regexp.exec(content)) !== null)
+                {
+                    var existingTag: string = matches[0];
+                    console.log(`Existing Tag: ${existingTag}`);
+                    var replacementTag: string = `${matches[1]}${newVersion}${matches[3]}`;
+                    console.log(`Replacement Tag: ${replacementTag}`);
+                    content = content.replace(existingTag, replacementTag);
+                }
+                fs.writeFileSync(file, content, fileEncoding.encoding);
+
             } else {
                 console.log(`Updating all version fields with ${newVersion}`);
                 const csprojVersionRegex = /(<\w+Version>)(.*)(<\/\w+Version>)/gmi;
@@ -133,7 +144,6 @@ if (files.length>0) {
                     console.log(`Replacement Tag: ${replacementTag}`);
                     content = content.replace(existingTag, replacementTag);
                 }
-
                 fs.writeFileSync(file, content, fileEncoding.encoding);
             }
             console.log (`${file} - version applied`);

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -24,6 +24,8 @@
     - Fixed Issue 167 with .NET Core versioning not applying correctly to nupkg and product version fields.
 - V1.23   - Fixed Issue 183 which broke due to V1.22 changing default behaviour.
 - V1.24   - Added task to version Android manifest files for Xamarin projects.
+- V1.25   - Fixed Issue 176 where the task assumes the existing version number matches the provided version number (PR from @esbenbach)
+          - Fixed Issue 185 where the task wasn't replacing existing version numbers correctly.
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of


### PR DESCRIPTION
Building on @esbenbach's changes to also cover the cases where a user could specify the name of a field to use but it was in a different format to the provided version number and regex.

Updated the readme for both changes as well.