### PR TITLE
Update filter to just look for specified file in any location under path - fixes #177

### DIFF
--- a/Extensions/Versioning/VersionAssembliesTask/ApplyVersionToAssemblies.ps1
+++ b/Extensions/Versioning/VersionAssembliesTask/ApplyVersionToAssemblies.ps1
@@ -1,10 +1,10 @@
 ##-----------------------------------------------------------------------
 ## <copyright file="ApplyVersionToAssemblies.ps1">(c) Microsoft Corporation. This source is subject to the Microsoft Permissive License. See http://www.microsoft.com/resources/sharedsource/licensingbasics/sharedsourcelicenses.mspx. All other rights reserved.</copyright>
 ##-----------------------------------------------------------------------
-# Look for a 0.0.0.0 pattern in the build number. 
+# Look for a 0.0.0.0 pattern in the build number.
 # If found use it to version the assemblies.
 #
-# For example, if the 'Build number format' build process parameter 
+# For example, if the 'Build number format' build process parameter
 # $(BuildDefinitionName)_$(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 # then your build numbers come out like this:
 # "Build HelloWorld_2013.07.19.1"
@@ -54,15 +54,15 @@ Write-verbose "Output: Version Number Parameter Name: $outputversion"
 $VersionData = [regex]::matches($VersionNumber,$VersionRegex)
 switch($VersionData.Count)
 {
-   0        
-      { 
+   0
+      {
          Write-Error "Could not find version number data in $VersionNumber."
          exit 1
       }
    1 {}
-   default 
-      { 
-         Write-Warning "Found more than instance of version data in $VersionNumber." 
+   default
+      {
+         Write-Warning "Found more than instance of version data in $VersionNumber."
          Write-Warning "Will assume first instance is version."
       }
 }
@@ -70,9 +70,7 @@ $NewVersion = $VersionData[0]
 Write-Verbose "Extracted Version: $NewVersion"
 
 # Apply the version to the assembly property files
-$files = Get-ChildItem $Path -recurse -include "*Properties*","My Project" | 
-    Where-Object { $_.PSIsContainer } | 
-    foreach { Get-ChildItem -Path $_.FullName -Recurse -include $FilenamePattern }
+$files = Get-ChildItem $Path -recurse -include $FilenamePattern
 if($files)
 {
     Write-Verbose "Will apply $NewVersion to $($files.count) files."
@@ -89,7 +87,7 @@ if($files)
             Write-Verbose "Updating only the '$field' version"
             $filecontent -replace "$field\(`"$VersionRegex", "$field(`"$NewVersion" | Out-File $file -Encoding $FileEncoding
         }
-        
+
         Write-Verbose "$file - version applied"
     }
     Write-Verbose "Set the output variable '$outputversion' with the value $NewVersion"

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -26,6 +26,7 @@
 - V1.24   - Added task to version Android manifest files for Xamarin projects.
 - V1.25   - Fixed Issue 176 where the task assumes the existing version number matches the provided version number (PR from @esbenbach)
           - Fixed Issue 185 where the task wasn't replacing existing version numbers correctly.
+          - Fixed Issue 177 where the task wouldn't find assembly info files if they weren't in specific folders.
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of


### PR DESCRIPTION
Previously the file searching was looking in Properties and similar folders but didn't account for specifying a location which had the assembly version file in the root of that path.