### PR TITLE
Add new locations for DacPac dlls to versioning tasks - Fixes #197

### DIFF
--- a/Extensions/Versioning/VersionDacpacTask/Update-DacPacVersionNumber.ps1
+++ b/Extensions/Versioning/VersionDacpacTask/Update-DacPacVersionNumber.ps1
@@ -35,7 +35,6 @@ param (
 
 )
 
-
 function Get-Toolpath
 {
     param(
@@ -52,33 +51,38 @@ function Get-Toolpath
             Write-Verbose 'Found a VS2017 SKU'
             ForEach ($folder in Get-ChildItem -Path $vs2017base)
             {
-                    $ToolPath = "$vs2017base\$folder\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130"
-                    Write-Verbose "Checking $ToolPath"
-                    if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+                    $TestPath = "$vs2017base\$folder\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130"
+                    Write-Verbose "Checking $TestPath"
+                    if (Test-Path ("$TestPath\Microsoft.SqlServer.Dac.Extensions.dll"))
                     {
                     Write-Verbose 'Found VS2017 SQL2016 (130) assemblies' -verbose
-                    return $ToolPath
+                    return $TestPath
                     }
             }
        }
        # for older versions we check each path
-        $ToolPath = 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130'
-        if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+        $TestPath = 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130'
+        if (Test-Path ("$TestPath\Microsoft.SqlServer.Dac.Extensions.dll"))
         {
            Write-Verbose 'Found VS2015 SQL2016 (130) assemblies' -verbose
-        } else
+           return $TestPath
+        }
+        else
         {
-            $ToolPath = 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120'
-            if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+            $TestPath = 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120'
+            if (Test-Path ("$TestPath\Microsoft.SqlServer.Dac.Extensions.dll"))
             {
-            Write-Verbose 'Found VS2015 SQL2014 (120) assemblies' -verbose
-            } else
+                Write-Verbose 'Found VS2015 SQL2014 (120) assemblies' -verbose
+                return $TestPath
+            }
+            else
             {
                 Write-Verbose 'Cound not find SQL2014 assemblies' -verbose
-                $ToolPath = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120'
-                if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+                $TestPath = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120'
+                if (Test-Path ("$TestPath\Microsoft.SqlServer.Dac.Extensions.dll"))
                 {
                     Write-Verbose 'Found VS2013 SQL2012 (120) assemblies' -verbose
+                    return $TestPath
                 }
                 else
                 {
@@ -86,24 +90,27 @@ function Get-Toolpath
                 }
             }
         }
-        $ToolPath = 'C:\Program Files\Microsoft SQL Server\140\DAC\bin'
-        if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+        $TestPath = 'C:\Program Files\Microsoft SQL Server\140\DAC\bin'
+        if (Test-Path ("$TestPath\Microsoft.SqlServer.Dac.Extensions.dll"))
         {
             Write-Verbose 'Found SQL2017 (140) assemblies' -verbose
+            return $TestPath
         }
         else
         {
-            $ToolPath = 'C:\Program Files\Microsoft SQL Server\130\DAC\bin'
-            if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+            $TestPath = 'C:\Program Files\Microsoft SQL Server\130\DAC\bin'
+            if (Test-Path ("$TestPath\Microsoft.SqlServer.Dac.Extensions.dll"))
             {
                 Write-Verbose 'Found SQL2016 (130) assemblies' -verbose
+                return $TestPath
             }
             else
             {
-                $ToolPath = 'C:\Program Files\Microsoft SQL Server\120\DAC\bin'
-                if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+                $TestPath = 'C:\Program Files\Microsoft SQL Server\120\DAC\bin'
+                if (Test-Path ("$TestPath\Microsoft.SqlServer.Dac.Extensions.dll"))
                 {
                     Write-Verbose 'Found SQL2014 (120) assemblies' -verbose
+                    return $TestPath
                 }
                 else
                 {
@@ -187,7 +194,6 @@ function Update-DacpacVerion
         Write-Warning "Failed to update DacPac $($DacPacObject.Name), due to error:"
         Write-Warning "$($error[0])"
     }
-
 }
 
 # check if we are in test mode i.e.

--- a/Extensions/Versioning/VersionDacpacTask/Update-DacPacVersionNumber.ps1
+++ b/Extensions/Versioning/VersionDacpacTask/Update-DacPacVersionNumber.ps1
@@ -5,7 +5,7 @@
     This script will update the version number of a specifed DACPAC file using the SQL DacPackage
     namespace methods. Catches any errors that occur on the versioning section and uses Write-Warning
     to output what went wrong, this is to prevent the whole build failing because it can't version some files
-    which haven't been versioned perviously. 
+    which haven't been versioned perviously.
 
     Any errors which are thrown by the DLLs not being available will return -1 exit code which will stop the build
     process however (as it's likely to cause other problems with those DLLs not being available).
@@ -66,7 +66,7 @@ function Get-Toolpath
         if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
         {
            Write-Verbose 'Found VS2015 SQL2016 (130) assemblies' -verbose
-        } else 
+        } else
         {
             $ToolPath = 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120'
             if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
@@ -78,24 +78,49 @@ function Get-Toolpath
                 $ToolPath = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120'
                 if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
                 {
-                    Write-Verbose 'Found VS2013 SQL2012 (120) assemblies' -verbose 
+                    Write-Verbose 'Found VS2013 SQL2012 (120) assemblies' -verbose
                 }
                 else
                 {
-                    Write-error "Cannot find DLLs in expected VS2013, VS2015 or VS2017 default locations" 
+                    Write-error "Cannot find DLLs in expected VS2013, VS2015 or VS2017 default locations"
                 }
             }
-        }  
-    } else
-    {
-        Write-Verbose "Looking for tools in user provided [$ToolPath]" -verbose
-        if (Test-Path "$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll") 
+        }
+        $ToolPath = 'C:\Program Files\Microsoft SQL Server\140\DAC\bin'
+        if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
         {
-             Write-Verbose 'Found assemblies in user provide location' -verbose 
+            Write-Verbose 'Found SQL2017 (140) assemblies' -verbose
         }
         else
         {
-             Write-error 'Cannot find assemblies in user provide location' -verbose 
+            $ToolPath = 'C:\Program Files\Microsoft SQL Server\130\DAC\bin'
+            if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+            {
+                Write-Verbose 'Found SQL2016 (130) assemblies' -verbose
+            }
+            else
+            {
+                $ToolPath = 'C:\Program Files\Microsoft SQL Server\120\DAC\bin'
+                if (Test-Path ("$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll"))
+                {
+                    Write-Verbose 'Found SQL2014 (120) assemblies' -verbose
+                }
+                else
+                {
+                    Write-error "Cannot find DLLs in expected SQL Server locations"
+                }
+            }
+        }
+    } else
+    {
+        Write-Verbose "Looking for tools in user provided [$ToolPath]" -verbose
+        if (Test-Path "$ToolPath\Microsoft.SqlServer.Dac.Extensions.dll")
+        {
+             Write-Verbose 'Found assemblies in user provide location' -verbose
+        }
+        else
+        {
+             Write-error 'Cannot find assemblies in user provide location' -verbose
         }
     }
 
@@ -115,7 +140,7 @@ function Update-DacpacVerion
         [string]$ToolPath
 
     )
-    
+
     #Specifying the Error Preference within the function scope to help catch errors
     $ErrorActionPreference = 'Stop'
 
@@ -165,22 +190,22 @@ function Update-DacpacVerion
 
 }
 
-# check if we are in test mode i.e. 
+# check if we are in test mode i.e.
 If ($VersionNumber -eq "" -and $path -eq "") {Exit}
 
 # Get and validate the version data
 $VersionData = [regex]::matches($VersionNumber,$VersionRegex)
 switch($VersionData.Count)
 {
-0        
-    { 
+0
+    {
         Write-Error "Could not find version number data in $VersionNumber."
         exit 1
     }
 1 {}
-default 
-    { 
-        Write-Warning "Found more than instance of version data in $VersionNumber." 
+default
+    {
+        Write-Warning "Found more than instance of version data in $VersionNumber."
         Write-Warning "Will assume first instance is version."
     }
 }

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -27,6 +27,7 @@
 - V1.25   - Fixed Issue 176 where the task assumes the existing version number matches the provided version number (PR from @esbenbach)
           - Fixed Issue 185 where the task wasn't replacing existing version numbers correctly.
           - Fixed Issue 177 where the task wouldn't find assembly info files if they weren't in specific folders.
+- V1.26   - Fixed Issue 197 where the task wouldn't correctly run on Hosted agents due to changes in the DacFx install location.
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of


### PR DESCRIPTION
Adds the SQL Server locations under `C:\Program Files (x86)` as it is the new install location of the DacFx files.