### PR TITLE
Update pester tests to use version with task.

### DIFF
--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -72,7 +72,7 @@ if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86") {
                 "$($_.Value)"
             }
         }
-        
+
     }
     write-warning "Re-launching in x86 PowerShell with $($args -join ' ')"
     &"$env:windir\syswow64\windowspowershell\v1.0\powershell.exe" -noprofile -executionpolicy bypass -file $myinvocation.Mycommand.path $args
@@ -83,15 +83,15 @@ write-verbose "Running in $($env:Processor_Architecture) PowerShell" -verbose
 if (([bool]::Parse($ForceUseOfPesterInTasks) -eq $true) -and $(-not([string]::IsNullOrEmpty($pesterVersion)))) {
     # we have no module path specified and Pester is not installed on the PC
     # have to use a version in this task
-    $moduleFolder = "$pwd\$pesterVersion"
+    $moduleFolder = "$PSScriptRoot\$pesterVersion"
     Write-Verbose "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension" -verbose
     Import-Module -Name $moduleFolder\Pester.psd1
 }
-elseif ([string]::IsNullOrEmpty($moduleFolder) -and 
+elseif ([string]::IsNullOrEmpty($moduleFolder) -and
     (-not(Get-Module -ListAvailable Pester))) {
     # we have no module path specified and Pester is not installed on the PC
     # have to use a version in this task
-    $moduleFolder = "$pwd\$pesterVersion"
+    $moduleFolder = "$PSScriptRoot\$pesterVersion"
     Write-Verbose "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension, as not installed on PC" -verbose
     Import-Module $moduleFolder\Pester.psd1
 }

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -127,11 +127,11 @@ Describe "Testing Pester Task" {
         mock Invoke-Pester {}
 
         it "Creates the output xml file correctly" {
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "False"
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "True" -PesterVersion '4.0.8'
             Test-Path -Path TestDrive:\Output.xml | Should -Be $True
         }
         it "Throws an error when pester tests fail" {
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -ForceUseOfPesterInTasks "False"
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -ForceUseOfPesterInTasks "True" -PesterVersion '4.0.8'
             Assert-MockCalled -CommandName Write-Error
         }
 
@@ -140,21 +140,21 @@ Describe "Testing Pester Task" {
             New-Item -Path TestDrive:\ -Name TestFile2.ps1 | Out-Null
             New-Item -Path TestDrive:\ -Name TestFile3.ps1 | Out-Null
 
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage.xml' -ForceUseOfPesterInTasks "False"
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage.xml' -ForceUseOfPesterInTasks "True" -PesterVersion '4.0.8'
             Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
         }
 
     }
 
     Context "Testing Pester Module Version Loading" {
-        
+
         it "Loads Pester version contained in task when ForceUse is set to true " {
             mock Invoke-Pester { }
             mock Import-Module { }
             Mock Write-Verbose { }
             Mock Write-Warning { }
             Mock Write-Error { }
-            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.0.8") } 
+            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.0.8") }
             Mock Get-ChildItem  { return $true }
 
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder $null -PesterVersion 4.0.8 -ForceUseOfPesterInTasks "True"
@@ -169,9 +169,9 @@ Describe "Testing Pester Task" {
             Mock Write-Verbose { }
             Mock Write-Warning { }
             Mock Write-Error { }
-            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.0.8") } 
+            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.0.8") }
             Mock Get-ChildItem  { return $true }
-     
+
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder $null -PesterVersion 4.0.8 -ForceUseOfPesterInTasks "False"
 
             Assert-MockCalled  Import-Module -ParameterFilter { $Name.EndsWith("\4.0.8\Pester.psd1") }
@@ -185,11 +185,11 @@ Describe "Testing Pester Task" {
             Mock Write-Warning { }
             Mock Write-Error { }
 
-            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("$pwd\3.4.3") } 
+            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("$pwd\3.4.3") }
             Mock Get-ChildItem  { return $true }
-     
+
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "$pwd\3.4.3" -PesterVersion 4.0.8 -ForceUseOfPesterInTasks "True"
-  
+
             Assert-MockCalled  Import-Module -ParameterFilter { $Name.EndsWith("\4.0.8\Pester.psd1") }
             Assert-MockCalled Invoke-Pester
         }
@@ -200,11 +200,11 @@ Describe "Testing Pester Task" {
             Mock Write-Verbose { }
             Mock Write-Warning { }
             Mock Write-Error { }
-            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.0.8") } 
+            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.0.8") }
             Mock Get-ChildItem  { return $true }
-  
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "   " -PesterVersion 4.0.8 -ForceUseOfPesterInTasks "False" 
-  
+
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "   " -PesterVersion 4.0.8 -ForceUseOfPesterInTasks "False"
+
             Assert-MockCalled  Import-Module -ParameterFilter { $Name.EndsWith("\4.0.8\Pester.psd1") }
             Assert-MockCalled Invoke-Pester
         }
@@ -215,8 +215,8 @@ Describe "Testing Pester Task" {
             Mock Write-Verbose { }
             Mock Write-Warning { }
             Mock Write-Error { }
-     
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "$pwd\3.4.3" -ForceUseOfPesterInTasks "False" 
+
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "$pwd\3.4.3" -ForceUseOfPesterInTasks "False"
             Assert-MockCalled  Import-Module -ParameterFilter { $Name -eq "$pwd\3.4.3\Pester.psd1" }
             Assert-MockCalled Invoke-Pester
         }
@@ -227,8 +227,8 @@ Describe "Testing Pester Task" {
             Mock Write-Verbose { }
             Mock Write-Warning { }
             Mock Write-Error { }
-     
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "False" 
+
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "False"
             Assert-MockCalled  Import-Module
             # can't check the presvious assert for empty parameters, so check the message
             Assert-MockCalled Write-Verbose -ParameterFilter { $Message -eq "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location" }

--- a/Extensions/Versioning/VersionDacpacTask/test/Get-Toolpath.tests.ps1
+++ b/Extensions/Versioning/VersionDacpacTask/test/Get-Toolpath.tests.ps1
@@ -2,89 +2,89 @@
 import-module "$PSScriptRoot\..\src\Update-DacPacVersionNumber.ps1"
 
 Describe "Use VS2013 SQL2012 120 ToolPath settings" {
-    Mock Test-Path  {return $false} -ParameterFilter { 
+    Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
-    Mock Test-Path  {return $false} -ParameterFilter { 
+    Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Microsoft.SqlServer.Dac.Extensions.dll"
-        } 
-    Mock Test-Path  {return $false} -ParameterFilter { 
+        }
+    Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130\Microsoft.SqlServer.Dac.Extensions.dll"
-        }     
-    Mock Test-Path  {return $true} -ParameterFilter { 
+        }
+    Mock Test-Path  {return $true} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Microsoft.SqlServer.Dac.Extensions.dll"
-        }     
- 
+        }
+
     It "Find DLLs" {
-        $path = Get-Toolpath -ToolPath "" 
+        $path = Get-Toolpath -ToolPath ""
         $path | Should be "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120"
     }
 }
 
 Describe "Use VS2015 SQL2014 120 ToolPath settings" {
-   Mock Test-Path  {return $false} -ParameterFilter { 
+   Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
-   Mock Test-Path  {return $false} -ParameterFilter { 
+   Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130\Microsoft.SqlServer.Dac.Extensions.dll"
-        } 
-   Mock Test-Path  {return $true} -ParameterFilter { 
+        }
+   Mock Test-Path  {return $true} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Microsoft.SqlServer.Dac.Extensions.dll"
-        } 
-       
+        }
+
     It "Find DLLs" {
-        $path = Get-Toolpath -ToolPath "" 
+        $path = Get-Toolpath -ToolPath ""
         $path | Should be "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120"
     }
 }
 
 Describe "Use VS2015 SQL2014 130 ToolPath settings" {
-   Mock Test-Path  {return $false} -ParameterFilter { 
+   Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
-   Mock Test-Path  {return $true} -ParameterFilter { 
+   Mock Test-Path  {return $true} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130\Microsoft.SqlServer.Dac.Extensions.dll"
-        } 
-       
+        }
+
     It "Find DLLs" {
-        $path = Get-Toolpath -ToolPath "" 
+        $path = Get-Toolpath -ToolPath ""
         $path | Should be "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130"
     }
 }
 
 Describe "Use VS2017 SQL2014 130 ToolPath settings" {
-   Mock Test-Path  {return $true} -ParameterFilter { 
+   Mock Test-Path  {return $true} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
         }
-   Mock Get-ChildItem {return "DevSku"} -ParameterFilter { 
+   Mock Get-ChildItem {return "DevSku"} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017"
-        } 
-   Mock Test-Path  {return $true} -ParameterFilter { 
+        }
+   Mock Test-Path  {return $true} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio\2017\DevSku\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130\Microsoft.SqlServer.Dac.Extensions.dll"
         }
-              
+
     It "Find DLLs" {
-        $path = Get-Toolpath -ToolPath "" 
+        $path = Get-Toolpath -ToolPath ""
         $path | Should be "C:\Program Files (x86)\Microsoft Visual Studio\2017\DevSku\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130"
     }
 }
 
 
 Describe "Use User ToolPath settings" {
-    Mock Test-Path  {return $false} -ParameterFilter { 
+    Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Microsoft.SqlServer.Dac.Extensions.dll"
-        } 
+        }
 
-     Mock Test-Path  {return $false} -ParameterFilter { 
+     Mock Test-Path  {return $false} -ParameterFilter {
             $Path -eq "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Microsoft.SqlServer.Dac.Extensions.dll"
-        }     
-       
-      Mock Test-Path  {return $true} -ParameterFilter { 
+        }
+
+      Mock Test-Path  {return $true} -ParameterFilter {
             $Path -eq "C:\mocked\Microsoft.SqlServer.Dac.Extensions.dll"
-        }  
+        }
 
     It "Find DLLs" {
-        $path = Get-Toolpath -ToolPath "C:\mocked" 
+        $path = Get-Toolpath -ToolPath "C:\mocked"
         $path | Should be "C:\mocked"
     }
 }
@@ -95,7 +95,7 @@ Describe "Cannot use User ToolPath settings" {
     Mock write-error -MockWith {return $msg -match "Mocked error"} -verifiable
 
     It "cannot Find DLLs" {
-        Get-Toolpath -ToolPath "C:\dummy" 
-        Assert-VerifiableMocks
+        Get-Toolpath -ToolPath "C:\dummy"
+        Assert-VerifiableMock
     }
 }


### PR DESCRIPTION
See #202 for details but short version is that some tests weren't loading the version of pester that shipped with the task and therefore the later tests were running using whichever version of Pester was available on the machine. This was causing some issues with mocking and more due to usually loading an older version.