### PR TITLE
Add option to to use a build number directly

### DIFF
--- a/Extensions/Versioning/VersionJSONFileTask/src/ApplyVersionToJSONFile.ts
+++ b/Extensions/Versioning/VersionJSONFileTask/src/ApplyVersionToJSONFile.ts
@@ -13,10 +13,12 @@ var field = tl.getInput("Field");
 var outputversion = tl.getInput("outputversion");
 var filenamePattern = tl.getInput("FilenamePattern");
 var versionForJSONFileFormat = tl.getInput("versionForJSONFileFormat");
+var useBuildNumberDirectly = tl.getBoolInput("useBuildNumberDirectly");
 
 console.log (`Source Directory:  ${path}`);
 console.log (`Filename Pattern: ${filenamePattern}`);
 console.log (`Version Number/Build Number: ${versionNumber}`);
+console.log (`Use Build Number Directly: ${useBuildNumberDirectly}`);
 console.log (`Version Filter to extract build number: ${versionRegex}`);
 console.log (`Version Format for JSON File: ${versionForJSONFileFormat}`);
 console.log (`Field to update (all if empty): ${field}`);
@@ -28,31 +30,37 @@ if (!fs.existsSync(path)) {
     process.exit(1);
 }
 
-// Get and validate the version data
-var regexp = new RegExp(versionRegex);
-var versionData = regexp.exec(versionNumber);
-if (!versionData) {
-    // extra check as we don't get zero size array but a null
-    tl.error(`Could not find version number data in ${versionNumber} that matches ${versionRegex}.`);
-    process.exit(1);
-}
-switch (versionData.length) {
-   case 0:
-         // this is trapped by the null check above
-         tl.error(`Could not find version number data in ${versionNumber} that matches ${versionRegex}.`);
-         process.exit(1);
-   case 1:
-        break;
-   default:
-         tl.warning(`Found more than instance of version data in ${versionNumber}  that matches ${versionRegex}.`);
-         tl.warning(`Will assume first instance is version.`);
-         break;
-}
+// work out if we need to extract the verson from the build
+let jsonVersion = versionNumber; // set the default value
+if (useBuildNumberDirectly === false) {
+    // Get and validate the version data
+    var regexp = new RegExp(versionRegex);
+    var versionData = regexp.exec(versionNumber);
+    if (!versionData) {
+        // extra check as we don't get zero size array but a null
+        tl.error(`Could not find version number data in ${versionNumber} that matches ${versionRegex}.`);
+        process.exit(1);
+    }
+    switch (versionData.length) {
+    case 0:
+            // this is trapped by the null check above
+            tl.error(`Could not find version number data in ${versionNumber} that matches ${versionRegex}.`);
+            process.exit(1);
+    case 1:
+            break;
+    default:
+            tl.warning(`Found more than instance of version data in ${versionNumber}  that matches ${versionRegex}.`);
+            tl.warning(`Will assume first instance is version.`);
+            break;
+    }
 
-var buildVersion = versionData[0];
-console.log (`Extracted Build Version: ${buildVersion}`);
-
-const jsonVersion = getSplitVersionParts(versionRegex, versionForJSONFileFormat, buildVersion);
+    console.log (`Extracting version from the build number`);
+    var buildVersion = versionData[0];
+    console.log (`Extracted Build Version: ${buildVersion}`);
+    jsonVersion = getSplitVersionParts(versionRegex, versionForJSONFileFormat, buildVersion);
+} else {
+    console.log (`Using the provided build number without any further processing`);
+}
 console.log (`JSON Version Name will be: ${jsonVersion}`);
 
 // Apply the version to the assembly property files

--- a/Extensions/Versioning/VersionJSONFileTask/task/task.json
+++ b/Extensions/Versioning/VersionJSONFileTask/task/task.json
@@ -45,13 +45,24 @@
          "helpMarkDown": "Version number to apply to files, can be extraced from the build name 'Build HelloWorld_00.00.00000.0' format"
       },
       {
-      "name": "VersionRegex",
-      "type": "string",
-      "label": "Regex Filter to extract build number",
-      "defaultValue": "\\d+\\.\\d+\\.\\d+\\.\\d+",
-      "required": true,
-      "helpMarkDown": "Regular expression filter to get build number from the build name.",
-      "groupName":"advanced"
+        "name": "useBuildNumberDirectly",
+        "type": "boolean",
+        "label": "Use Version Number without processing",
+        "defaultValue": "False",
+        "required": true,
+        "helpMarkDown": "Use the version number parameter without any further processing",
+        "groupName":"advanced"
+      },
+
+      {
+        "name": "VersionRegex",
+        "type": "string",
+        "label": "Regex Filter to extract build number",
+        "defaultValue": "\\d+\\.\\d+\\.\\d+\\.\\d+",
+        "required": true,
+        "helpMarkDown": "Regular expression filter to get build number from the build name.",
+        "groupName":"advanced",
+        "visibleRule": "useBuildNumberDirectly = false"
     },
     {
       "name": "versionForJSONFileFormat",
@@ -60,7 +71,8 @@
       "defaultValue": "{1}.{2}.{3}",
       "required": true,
       "helpMarkDown": "Format of version number to apply as Version in the JSON File.",
-      "groupName":"advanced"
+      "groupName":"advanced",
+      "visibleRule": "useBuildNumberDirectly = false"
     },
       {
       "name": "FilenamePattern",
@@ -80,7 +92,7 @@
       "helpMarkDown": "The version field to update, if blank all version fields are updated usually \"version\": \"1.1.1\"",
       "groupName":"advanced"
     },
-      {
+    {
       "name": "OutputVersion",
       "type": "string",
       "label": "Version number used variable name",

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -34,6 +34,7 @@
 - V1.29   - Issue #217 moved the ANdroid versioner to NodeJS
 - V1.30   - Issue #222 allowed more complex delimiters in version number format
 - V1.31   - Issue #233 added JSON and Angular versioner
+- V1.32   - Allow override of processing of build number to extract the version number, the provided build number parameter is used directly
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -34,7 +34,7 @@
 - V1.29   - Issue #217 moved the ANdroid versioner to NodeJS
 - V1.30   - Issue #222 allowed more complex delimiters in version number format
 - V1.31   - Issue #233 added JSON and Angular versioner
-- V1.32   - Allow override of processing of build number to extract the version number, the provided build number parameter is used directly
+- V1.32   - Issue #254 allow version extraction to be bypassed for JSON Versioner 
 
 A set of tasks based on the versioning sample script to version tamping assemblies shown in the [VSTS documentation](https://msdn.microsoft.com/Library/vs/alm/Build/scripts/index
 ). These allow versioning of


### PR DESCRIPTION
Add option to to apply a build number directly for a JSON file without any version number extraction processing