### PR TITLE
Fixed encoding for work items with cyrillic symbols

### DIFF
--- a/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.psm1
+++ b/Extensions/GenerateReleaseNotes/GenerateReleaseNotesTask/GenerateReleaseNotes.psm1
@@ -293,7 +293,6 @@ function Invoke-GetCommand {
     $debugpat = $env:PAT
 
     $webclient = new-object System.Net.WebClient
-    $webclient.Encoding = [System.Text.Encoding]::UTF8
 	
     if ([System.Convert]::ToBoolean($usedefaultcreds) -eq $true) {
         Write-Verbose "Using default credentials"


### PR DESCRIPTION
Removed the encoding setting for webclient

Fixed next issue:
If the work item contains Cyrillic symbols in the subject, then they are replaced by a question mark