### PR TITLE
Remove extra functionality for handling module versions -fixes #312

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -12,8 +12,6 @@ The main ones are
 The advanced ones are
 
 - Should the instance of PowerShell used to run the test be forced to run in 32bit, defaults to false.
-- (New in 5.x) You can pick if the Pester 3.4.3 or 4.3.1 modules (both are included in the task) are used
-- If neither 3.4.3 or 4.3.1 is suitable then a custom module path pointing to where the required Pester.psd1 and related files are stored can be entered. This will be used in preference to the embedded versions
 
 The Pester task does not in itself upload the test results, it just throws an error if tests fails. It relies on the standard test results upload task.
 
@@ -45,3 +43,4 @@ Releases
     - Fix check for code coverage folder being specified to ensure code coverage is generated from the correct files rather than files under $ScriptFolder. ([Fixes #330](https://github.com/rfennell/vNextBuild/issues/330))
     - Swap logging to use Write-Host to ensure it logs out by default. ([Fixes #320](https://github.com/rfennell/vNextBuild/issues/320))
     - Change Hashtable parsing function to use language parser to handle more cases. ([Fixes #321](https://github.com/rfennell/vNextBuild/issues/321))
+- 8.0.x - Removed complicated version loading logic and replaced with installing the latest version from the gallery if you're on PSv5+ or have PowerShellGet available. If neither of those are options then it will load the 4.3.1 version of Pester that ships with the task. ([PR#314](https://github.com/rfennell/vNextBuild/pull/314))

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -69,7 +69,7 @@ if (Get-Module -Name PowerShellGet -ListAvailable) {
         Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
     }
     $NewestPester = Find-Module -Name Pester
-    If ((Get-Module Pester -ListAvailable)[0].Version -lt $NewestPester.Version) {
+    If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
         Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery -SkipPublisherCheck
     }
 }

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -62,8 +62,13 @@ if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
 }
 
 if (Get-Module -Name PowerShellGet -ListAvailable) {
-    Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
-    Install-Module -Name Pester -Scope CurrentUser -Force -Repository (Get-PSRepository)[0].Name
+    if (-not(Get-PackageProvider -Name NuGet)) {
+        Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
+    }
+    $NewestPester = Find-Module -Name Pester
+    If ((Get-Module Pester -ListAvailable).Version -lt $NewestPester.Version) {
+        Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery
+    }
 }
 else {
     Import-Module "$PSScriptRoot\4.3.1\Pester.psd1" -force

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -62,7 +62,7 @@ if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
 }
 
 if ($PSVersionTable.PSVersion.Major -ge 5 -or (Get-Module -Name PowerShellGet -ListAvailable)) {
-    Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck -Confirm:$false -Repository (Get-PSRepository)[0].Name
+    Install-Module -Name Pester -Scope CurrentUser -Force -Confirm:$false -Repository (Get-PSRepository)[0].Name
 }
 else {
     Import-Module "$PSScriptRoot\4.3.1\Pester.psd1" -force

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -66,7 +66,7 @@ if (Get-Module -Name PowerShellGet -ListAvailable) {
         Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
     }
     $NewestPester = Find-Module -Name Pester
-    If ((Get-Module Pester -ListAvailable).Version -lt $NewestPester.Version) {
+    If ((Get-Module Pester -ListAvailable)[0].Version -lt $NewestPester.Version) {
         Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery
     }
 }

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -70,7 +70,7 @@ if (Get-Module -Name PowerShellGet -ListAvailable) {
     }
     $NewestPester = Find-Module -Name Pester
     If ((Get-Module Pester -ListAvailable)[0].Version -lt $NewestPester.Version) {
-        Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery
+        Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery -SkipPublisherCheck
     }
 }
 else {

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -62,7 +62,10 @@ if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
 }
 
 if (Get-Module -Name PowerShellGet -ListAvailable) {
-    if (-not(Get-PackageProvider -Name NuGet)) {
+    try {
+        $null = Get-PackageProvider -Name NuGet -ErrorAction Stop
+    }
+    catch {
         Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
     }
     $NewestPester = Find-Module -Name Pester

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -61,7 +61,7 @@ if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
     $env:PSModulePath = $additionalModulePath + ';' + $env:PSModulePath
 }
 
-if (Get-Module -Name PowerShellGet -ListAvailable) {
+if ((Get-Module -Name PowerShellGet -ListAvailable) -and (Get-Command Install-Module).Parameters.ContainsKey('SkipPublisherCheck')) {
     try {
         $null = Get-PackageProvider -Name NuGet -ErrorAction Stop
     }

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -62,7 +62,8 @@ if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
 }
 
 if ($PSVersionTable.PSVersion.Major -ge 5 -or (Get-Module -Name PowerShellGet -ListAvailable)) {
-    Install-Module -Name Pester -Scope CurrentUser -Force -Confirm:$false -Repository (Get-PSRepository)[0].Name
+    Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
+    Install-Module -Name Pester -Scope CurrentUser -Force -Repository (Get-PSRepository)[0].Name
 }
 else {
     Import-Module "$PSScriptRoot\4.3.1\Pester.psd1" -force

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -61,7 +61,7 @@ if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
     $env:PSModulePath = $additionalModulePath + ';' + $env:PSModulePath
 }
 
-if ($PSVersionTable.PSVersion.Major -ge 5 -or (Get-Module -Name PowerShellGet -ListAvailable)) {
+if (Get-Module -Name PowerShellGet -ListAvailable) {
     Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
     Install-Module -Name Pester -Scope CurrentUser -Force -Repository (Get-PSRepository)[0].Name
 }

--- a/Extensions/Pester/task/task.json
+++ b/Extensions/Pester/task/task.json
@@ -2,7 +2,7 @@
   "id": "31EF0033-64E3-4C55-B888-F446541474A6",
   "name": "Pester",
   "friendlyName": "Pester Test Runner from Black Marble",
-  "description": "Run Pester tests without the need to install Pester in with the PMModule folder or in the source repo (Using Pester 3.4.3 or 4.3.1)",
+  "description": "Run Pester tests by either installing the latest version of Pester at run time (if possible) or using the version shipped with the task (4.3.1)",
   "helpMarkDown": "Version: #{Build.BuildNumber}#. [More Information](https://github.com/rfennell/vNextBuild/wiki/Pester-Task/)",
   "category": "Test",
   "visibility": [
@@ -73,19 +73,6 @@
       "groupName": "tags"
     },
     {
-      "name": "pesterVersion",
-      "type": "pickList",
-      "label": "Pester version (stored in task)",
-      "defaultValue": "4.3.1",
-      "required": true,
-      "helpMarkDown": "Version of Pester to use from a choice of versions shipped in task. Will be used if Pester not installed in agent, or ForceUsage parameter set",
-      "groupName": "advanced",
-      "options": {
-        "3.4.3": "3.4.3",
-        "4.3.1": "4.3.1"
-      }
-    },
-    {
       "name": "additionalModulePath",
       "type": "string",
       "label": "Path to additional PowerShell modules",
@@ -110,24 +97,6 @@
       "defaultValue": "False",
       "required": true,
       "helpMarkDown": "Run in 32bit",
-      "groupName": "advanced"
-    },
-    {
-      "name": "moduleFolder",
-      "type": "string",
-      "label": "Module Folder override",
-      "defaultValue": "",
-      "required": false,
-      "helpMarkDown": "If left blank the Pester module stored in this task will be used, to load the Pester module from elsewhere set the path",
-      "groupName": "advanced"
-    },
-    {
-      "name": "ForceUseOfPesterInTasks",
-      "type": "boolean",
-      "label": "Force the use of a Pester Module shipped within this task",
-      "defaultValue": "False",
-      "required": true,
-      "helpMarkDown": "Force the use of the Pester version shipped in this task, even if Pester installed on agent.",
       "groupName": "advanced"
     }
   ],

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -27,15 +27,6 @@ Describe "Testing Pester Task" {
         it "CodeCoverageFolder is not Mandatory" {
             (Get-Command $sut).Parameters['CodeCoverageFolder'].Attributes.Mandatory | Should -Be $False
         }
-        it "Throws Exception when passed an invalid path for ModuleFolder" {
-            {&$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder TestDrive:\RandomFolder} | Should -Throw
-        }
-        it "Throws Exception when passed a path which doesn't contain Pester for ModuleFolder" {
-            {&$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder TestDrive:\} | Should -Throw
-        }
-        it "ModuleFolder is not Mandatory" {
-            (Get-Command $sut).Parameters['ModuleFolder'].Attributes.Mandatory | Should -Be $False
-        }
         it "Tag is not Mandatory" {
             (Get-Command $sut).Parameters['Tag'].Attributes.Mandatory | Should -Be $False
         }
@@ -51,8 +42,9 @@ Describe "Testing Pester Task" {
             Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
+            Mock Install-Module { }
 
-            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -Tag 'Infrastructure,Integration' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -Tag 'Infrastructure,Integration'
             $Tag.Length | Should Be 2
             Write-Output -NoEnumerate $Tag | Should -BeOfType [System.Array]
             Write-Output -NoEnumerate $Tag | Should -BeOfType [String[]]
@@ -66,8 +58,9 @@ Describe "Testing Pester Task" {
             Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
+            Mock Install-Module { }
 
-            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ExcludeTag 'Example,Demo' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ExcludeTag 'Example,Demo'
             $ExcludeTag.Length | Should be 2
             Write-Output -NoEnumerate $ExcludeTag | Should -BeOfType [System.Array]
             Write-Output -NoEnumerate $ExcludeTag | Should -BeOfType [String[]]
@@ -79,8 +72,9 @@ Describe "Testing Pester Task" {
             Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
+            Mock Install-Module { }
 
-            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\Output.xml -CodeCoverageOutputFile $null -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\Output.xml -CodeCoverageOutputFile $null
             Assert-MockCalled Invoke-Pester
         }
 
@@ -97,17 +91,18 @@ Describe "Testing Pester Task" {
         Mock Write-Host { }
         Mock Write-Warning { }
         Mock Write-Error { }
+        Mock Install-Module { }
 
         it "Calls Invoke-Pester correctly with ScriptFolder and ResultsFile specified" {
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
             Assert-MockCalled Invoke-Pester
         }
         it "Calls Invoke-Pester with Tag specified" {
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -Tag 'Infrastructure' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -Tag 'Infrastructure'
             Assert-MockCalled Invoke-Pester -ParameterFilter {$Tag -and $Tag -eq 'Infrastructure'}
         }
         it "Calls Invoke-Pester with ExcludeTag specified" {
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ExcludeTag 'Example' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ExcludeTag 'Example'
             Assert-MockCalled Invoke-Pester -ParameterFilter {$ExcludeTag -and $ExcludeTag -eq 'Example'}
         }
         it "Calls Invoke-Pester with the CodeCoverageOutputFile specified" {
@@ -115,11 +110,11 @@ Describe "Testing Pester Task" {
             New-Item -Path TestDrive:\ -Name TestFile2.ps1 | Out-Null
             New-Item -Path TestDrive:\ -Name TestFile3.ps1 | Out-Null
 
-            &$Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\Output.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage.xml' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\Output.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage.xml'
             Assert-MockCalled Invoke-Pester -ParameterFilter {$CodeCoverageOutputFile -and $CodeCoverageOutputFile -eq 'TestDrive:\codecoverage.xml'}
         }
         it "Should update the `$Env:PSModulePath correctly when additionalModulePath is supplied" {
-            &$Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\Output.xml -additionalModulePath TestDrive:\TestFolder -ForceUseOfPesterInTasks "True"
+            &$Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\Output.xml -additionalModulePath TestDrive:\TestFolder
 
             $Env:PSModulePath | Should -Match ';{0,1}TestDrive:\\TestFolder;{0,1}'
         }
@@ -137,6 +132,7 @@ Describe "Testing Pester Task" {
         Mock Write-Host { }
         Mock Write-Warning { }
         Mock Import-Module { }
+        Mock Install-Module { }
         Mock Write-Error { }
         mock Invoke-Pester {
             param ($OutputFile)
@@ -158,11 +154,11 @@ Describe "Testing Pester Task" {
         mock Invoke-Pester {}
 
         it "Creates the output xml file correctly" {
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
             Test-Path -Path TestDrive:\Output.xml | Should -Be $True
         }
         it "Throws an error when pester tests fail" {
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml
             Assert-MockCalled -CommandName Write-Error
         }
 
@@ -171,7 +167,7 @@ Describe "Testing Pester Task" {
             New-Item -Path TestDrive:\ -Name TestFile2.ps1 | Out-Null
             New-Item -Path TestDrive:\ -Name TestFile3.ps1 | Out-Null
 
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage.xml' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage.xml'
             Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
         }
 
@@ -207,93 +203,34 @@ Describe "Testing Pester Task" {
 
     Context "Testing Pester Module Version Loading" {
 
-        it "Loads Pester version contained in task when ForceUse is set to true " {
+        it "Installs the latest version of Pester when on PS5+ and PowerShellGet is available" {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Host { }
+            Mock Install-Module { $true }
+            Mock Write-hpst { }
             Mock Write-Warning { }
             Mock Write-Error { }
             Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
             Mock Get-ChildItem  { return $true }
 
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder $null -PesterVersion 4.3.1 -ForceUseOfPesterInTasks "True"
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
 
-            Assert-MockCalled  Import-Module -ParameterFilter { $Name.EndsWith("\4.3.1\Pester.psd1") }
+            Assert-MockCalled  Install-Module
             Assert-MockCalled Invoke-Pester
         }
 
-        it "Loads Pester version contained in task as Pester not installed on agent and ModuleFolder is Null " {
+        <#it "Loads Pester version that ships with task when not on PS5+ or PowerShellGet is unavailable" {
             mock Invoke-Pester { }
             mock Import-Module { }
             Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
-            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
-            Mock Get-ChildItem  { return $true }
+            mock Get-Module { }
 
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder $null -PesterVersion 4.3.1 -ForceUseOfPesterInTasks "False"
-
-            Assert-MockCalled  Import-Module -ParameterFilter { $Name.EndsWith("\4.3.1\Pester.psd1") }
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
+            Assert-MockCalled  Import-Module -ParameterFilter { $Name -eq "$pwd\4.3.1\Pester.psd1" }
             Assert-MockCalled Invoke-Pester
-        }
-
-        it "Loads Pester version contained in task when ForceUse is set to true even when ModuleFolder is set " {
-            mock Invoke-Pester { }
-            mock Import-Module { }
-            Mock Write-Host { }
-            Mock Write-Warning { }
-            Mock Write-Error { }
-
-            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("$pwd\3.4.3") }
-            Mock Get-ChildItem  { return $true }
-
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "$pwd\3.4.3" -PesterVersion 4.3.1 -ForceUseOfPesterInTasks "True"
-
-            Assert-MockCalled  Import-Module -ParameterFilter { $Name.EndsWith("\4.3.1\Pester.psd1") }
-            Assert-MockCalled Invoke-Pester
-        }
-
-        it "Loads Pester version contained in task as Pester not installed on agent and ModuleFolder contains whitespace " {
-            mock Invoke-Pester { }
-            mock Import-Module { }
-            Mock Write-Host { }
-            Mock Write-Warning { }
-            Mock Write-Error { }
-            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
-            Mock Get-ChildItem  { return $true }
-
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "   " -PesterVersion 4.3.1 -ForceUseOfPesterInTasks "False"
-
-            Assert-MockCalled  Import-Module -ParameterFilter { $Name.EndsWith("\4.3.1\Pester.psd1") }
-            Assert-MockCalled Invoke-Pester
-        }
-
-        it "Loads Pester version specified by ModuleFolder " {
-            mock Invoke-Pester { }
-            mock Import-Module { }
-            Mock Write-Host { }
-            Mock Write-Warning { }
-            Mock Write-Error { }
-
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ModuleFolder "$pwd\3.4.3" -ForceUseOfPesterInTasks "False"
-            Assert-MockCalled  Import-Module -ParameterFilter { $Name -eq "$pwd\3.4.3\Pester.psd1" }
-            Assert-MockCalled Invoke-Pester
-        }
-
-        it "Loads default Pester version if ModuleFolder and Force use of task contained version not set" {
-            mock Invoke-Pester { }
-            mock Import-Module { }
-            Mock Write-Host { }
-            Mock Write-Warning { }
-            Mock Write-Error { }
-
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "False"
-            Assert-MockCalled  Import-Module
-            # can't check the previous assert for empty parameters, so check the message
-            Assert-MockCalled Write-Host -ParameterFilter { $Object -eq "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location" }
-            Assert-MockCalled Invoke-Pester
-        }
-
+        }#>
     }
 
 }

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -235,7 +235,7 @@ Describe "Testing Pester Task" {
             Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
             Mock Get-ChildItem  { return $true }
             Mock Find-Module { [PsCustomObject]@{Version=[version]::new(9,9,9)}}
-            Mock Get-PackageProvider { $false }
+            Mock Get-PackageProvider { throw }
             Mock Install-PackageProvider {}
 
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -219,6 +219,7 @@ Describe "Testing Pester Task" {
         Mock Write-host { }
         Mock Write-Warning { }
         Mock Write-Error { }
+        Mock Get-Command { [PsCustomObject]@{Parameters=@{SkipPublisherCheck='SomeValue'}}}
 
         it "Installs the latest version of Pester when on PS5+ and PowerShellGet is available" {
             Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
@@ -257,6 +258,18 @@ Describe "Testing Pester Task" {
             Assert-MockCalled Invoke-Pester
         }
 
+        it "Should not Install the latest version of Pester when on PowerShellGet is available but SkipPublisherCheck is not available" {
+            Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
+            Mock Get-ChildItem  { return $true }
+            Mock Find-Module { [PsCustomObject]@{Version=[version]::new(9,9,9)}}
+            Mock Get-PackageProvider { $True }
+            Mock Get-Command { [PsCustomObject]@{Parameters=@{OtherProperty='SomeValue'}} }
+
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
+
+            Assert-MockCalled Install-Module -Times 0 -Scope It
+            Assert-MockCalled Invoke-Pester
+        }
         <#it "Loads Pester version that ships with task when not on PS5+ or PowerShellGet is unavailable" {
             mock Invoke-Pester { }
             mock Import-Module { }

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -120,7 +120,7 @@ Describe "Testing Pester Task" {
         }
         it "Should Write-Host the contents of Script parameters as a string version of a hashtable when a hashtable is provided" {
             $Parameters = "@{Path = '$PSScriptRoot\parameters.tests.ps1';Parameters=@{TestValue='SomeValue'}}"
-            &$Sut -ScriptFolder $Parameters -ResultsFile TestDrive:\Output.xml -ForceUseOfPesterInTasks 'True'
+            &$Sut -ScriptFolder $Parameters -ResultsFile TestDrive:\Output.xml
 
             Assert-MockCalled -CommandName Write-Host -ParameterFilter {
                 $Object -eq "Running Pester from using the script parameter [$Parameters] output sent to [TestDrive:\Output.xml]"
@@ -179,7 +179,7 @@ Describe "Testing Pester Task" {
             New-Item -Path TestDrive:\ -Name Source -ItemType Directory | Out-Null
             New-Item -Path TestDrive:\Source -Name Code.ps1 | Out-Null
 
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage2.xml' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage2.xml'
             Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
 
             Assert-MockCalled -CommandName Invoke-Pester -ParameterFilter {$CodeCoverage -and $CodeCoverage -contains "$((Get-Item 'TestDrive:\').FullName)Source\Code.ps1"}
@@ -193,7 +193,7 @@ Describe "Testing Pester Task" {
             New-Item -Path TestDrive:\ -Name Source -ItemType Directory -Force | Out-Null
             New-Item -Path TestDrive:\Source -Name Code.ps1 -Force | Out-Null
 
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage3.xml' -CodeCoverageFolder 'TestDrive:\Source' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage3.xml' -CodeCoverageFolder 'TestDrive:\Source'
             Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
 
             Assert-MockCalled -CommandName Invoke-Pester -ParameterFilter {$CodeCoverage -and $CodeCoverage -eq "$((Get-Item 'TestDrive:\').FullName)Source\Code.ps1" -and $CodeCoverage -notlike "$((Get-Item 'TestDrive:\').FullName)Tests\*.ps1"}
@@ -207,7 +207,7 @@ Describe "Testing Pester Task" {
             mock Invoke-Pester { }
             mock Import-Module { }
             Mock Install-Module { $true }
-            Mock Write-hpst { }
+            Mock Write-host { }
             Mock Write-Warning { }
             Mock Write-Error { }
             Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }


### PR DESCRIPTION
The complex version loading logic was more convoluted than it needed
to be. Simplify it down to just always installing the latest version
if PSv5+ or PowerShellGet is available. If not then import the module
shipped with the task.

### Is there a related Issue?
#312
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
