### PR TITLE
Fix parameter name

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V2/GenerateReleaseNotes.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V2/GenerateReleaseNotes.ts
@@ -28,7 +28,7 @@ async function run(): Promise<void>  {
             let releaseDefinitionId: number = parseInt(tl.getVariable("Release.DefinitionId"));
 
             // Inputs
-            let environmentName: string = (tl.getInput("overrideStage") || tl.getVariable("Release_EnvironmentName")).toLowerCase();
+            let environmentName: string = (tl.getInput("overrideStageName") || tl.getVariable("Release_EnvironmentName")).toLowerCase();
             var templateLocation = tl.getInput("templateLocation", true);
             var templateFile = tl.getInput("templatefile");
             var inlineTemplate = tl.getInput("inlinetemplate");

--- a/Extensions/XplatGenerateReleaseNotes/readme.md
+++ b/Extensions/XplatGenerateReleaseNotes/readme.md
@@ -115,3 +115,4 @@ Using the settings for the output file shown above, the release notes will be cr
 - 1.8 - Issue272 Fixed problem with no output if the artifact source is not a VSTS hosted repository
 - 1.9 - Issue277 fixed vulnerability in Moment 2.19.1 NPM package, no functional change
 - 2.0 - Major refactor PR305 by @gregpakes to move to newer API, does contain breaking changes to template. Hence from this point both V1 and V2 will be shipped in the same extension
+- 2.1 - Issue315 with PR316 by @marco-gallinari to fix incorrect mapping of stage override parameter


### PR DESCRIPTION
As per issue #315, the override should be working properly if linked to the proper input name

### What problem does this PR address?
difference between input name in task.json and input used in task code
  
### Is there a related Issue?
#315 
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
