### PR TITLE
Swap to using Language.Parser to parse the input string -fixes #321

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -41,3 +41,5 @@ Releases
 - 6.3.x - Engineering test same as 7.0.x
 - 7.0.x - PR287 changed included version of 4x Pester from 4.0.8 to 4.3.1, incremented major version as change of advanced options blocks auto update.
 - 7.1.x - Added additionalModulePath and CodeCoverageFolder, to support testing compiled modules ([PR#285](https://github.com/rfennell/vNextBuild/pull/285))
+- 7.2.x - Multiple fixes:
+    - Change Hashtable parsing function to use language parser to handle more cases. ([Fixes #321](https://github.com/rfennell/vNextBuild/issues/321))

--- a/Extensions/Pester/task/HelperModule.psm1
+++ b/Extensions/Pester/task/HelperModule.psm1
@@ -2,77 +2,18 @@ function Get-HashtableFromString
 {
     param
     (
-        [string]$line
+        [string]$lineInput
     )
 
     # check for empty first
-    If ([String]::IsNullOrEmpty($line)) {
+    If ([String]::IsNullOrEmpty($lineInput.trim(';'))) {
         return @{}
     }
 
-    # find first { and remove
-    $firstBracket = $line.IndexOf("{")
-    $lastBracket = $line.LastIndexOf("}")
-
-    # not valid format
-    if (($firstBracket -eq -1) -or ($lastBracket -eq -1))
-    {
-        return @{}
+    Foreach ($line in ($lineInput -split '(?<=}\s*),')) {
+        # Use the language parser to safely parse the hashtable string into a real hashtable.
+        [System.Management.Automation.Language.Parser]::ParseInput($line, [Ref]$null, [Ref]$null).Find({
+            $args[0] -is [System.Management.Automation.Language.HashtableAst]
+        }, $false).SafeGetValue()
     }
-        
-    # strip the outside brackets
-    $line = $line.substring($firstBracket+1, $lastBracket-$firstBracket-1).Trim()
-
-     #find first param
-    $nextSemiColon = $line.IndexOf(";")
-    $nextEquals = $line.IndexOf("=")
-    $nextAt = $line.IndexOf("@")
-    $lastBracket = $line.IndexOf("}")
-    $hashtable = @{}
-
-    while ($nextEquals -gt -1 )
-    {
-        
-        if ($nextSemiColon -eq -1)
-        {
-            # flags this is the last block
-            $nextSemiColon = $line.length
-        }
-
-        $param = $line.substring(0, $nextEquals).trim()
-        
-        if (($nextAt -eq -1) -or ($nextAt -gt $nextSemiColon))
-        {
-            # we have a string value
-            $value = $line.substring($nextEquals+1, $nextSemiColon-$nextEquals-1).trim().replace("`"","").replace("'","")
-            if ($line.length -ne $nextSemiColon)
-            {
-                $line = $line.remove(0,$nextSemiColon+1)
-            } else
-            {
-                $line = ""
-            }
-        } else
-        {
-            # we have a hashtable value
-            $value = Get-HashtableFromString -line $line.substring($nextEquals+1, $lastBracket-$nextEquals).trim()
-            $line = $line.remove(0,$lastBracket+1)
-        }
-        
-        $hashtable.Add($param, $value)
-
-        # and any leading ;
-        if ($line.startswith(";"))
-        {
-            $line = $line.remove(0,1)
-        }
-
-        $nextSemiColon = $line.IndexOf(";")
-        $nextEquals = $line.IndexOf("=")
-        $nextAt = $line.IndexOf("@")
-        $lastBracket = $line.IndexOf("}")
-        
-    }
-
-    return $hashtable
 }

--- a/Extensions/Pester/test/PesterTask/Helper.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Helper.Tests.ps1
@@ -39,11 +39,6 @@ Describe "Testing Helper Functions" {
             $actual.Parameters2.param2 | Should -Be "222"
         }
 
-        it "Cannot parse block with non-matching brackets" {
-            # need the outer {} for =throw to work
-           { Get-HashtableFromString -line "@{Path='C:\path\123'; Parameters=@{param1='111'; param2='222'}" } | Should -Throw # ArgumentOutOfRangeException
-        }
-
         it "Can parse block with trailing ;" {
             $actual = Get-HashtableFromString -line "@{Path='C:\path\123'; Parameters=@{param1='111'; param2='222'}};"
             $actual.Path | Should -Be "C:\path\123"
@@ -52,7 +47,7 @@ Describe "Testing Helper Functions" {
         }
 
         it "Can parse three part block 1" {
-            $actual = Get-HashtableFromString -line "@{Path='C:\path\123';  x=y; Parameters=@{param1='111'; param2='222'}}"
+            $actual = Get-HashtableFromString -line "@{Path='C:\path\123';  x='y'; Parameters=@{param1='111'; param2='222'}}"
             $actual.Path | Should -Be "C:\path\123"
             $actual.Parameters.param1 | Should -Be "111"
             $actual.Parameters.param2 | Should -Be "222"
@@ -60,11 +55,30 @@ Describe "Testing Helper Functions" {
         }
 
         it "Can parse three part block 2" {
-            $actual = Get-HashtableFromString -line "@{Path='C:\path\123'; Parameters=@{param1='111'; param2='222'}; x=y}"
+            $actual = Get-HashtableFromString -line "@{Path='C:\path\123'; Parameters=@{param1='111'; param2='222'}; x='y'}"
             $actual.Path | Should -Be "C:\path\123"
             $actual.Parameters.param1 | Should -Be "111"
             $actual.Parameters.param2 | Should -Be "222"
             $actual.x | Should -Be "y"
+        }
+        it "Can parse hashtable with ; in a value" {
+            $actual = Get-HashtableFromString -line "@{Path='.\tests\script.tests.ps1'; Parameters=@{someVar='this'}},@{Path='.\tests\script2.tests.ps1'; Parameters=@{otherparam='foo.txt;bar.txt'}}"
+            $actual.GetType().BaseType | Should -Be "Array"
+            $actual[0].Path | Should -Be '.\tests\script.tests.ps1'
+            $actual[0].Parameters.SomeVar | Should -Be 'this'
+            $actual[1].Path | Should -Be '.\tests\script2.tests.ps1'
+            $actual[1].Parameters.otherparam | Should -Be 'foo.txt;bar.txt'
+        }
+        it "Can parse hashtable with commas in a value" {
+            $actual = Get-HashtableFromString -line "@{Path='.\tests\script.tests.ps1'; Parameters=@{someVar='this'}},@{Path='.\tests\script2.tests.ps1'; Parameters=@{otherparam='foo.txt;bar.txt';Param2='ValueGoesHere'}},@{path='.\tests\script3.tests.ps1';Parameters=@{inputvar='var,this,string'}}"
+            $actual.GetType().BaseType | Should -Be "Array"
+            $actual[0].Path | Should -Be '.\tests\script.tests.ps1'
+            $actual[0].Parameters.SomeVar | Should -Be 'this'
+            $actual[1].Path | Should -Be '.\tests\script2.tests.ps1'
+            $actual[1].Parameters.otherparam | Should -Be 'foo.txt;bar.txt'
+            $actual[1].Parameters.Param2 | Should -Be 'ValueGoesHere'
+            $actual[2].Path | Should -Be '.\tests\script3.tests.ps1'
+            $actual[2].Parameters.inputvar | Should -Be 'var,this,string'
         }
 
 


### PR DESCRIPTION
Language.Parser can safely parse strings into their hashtable version and handles a few more use cases, like missing } and odd strings with ; and such in them. 

Added support for arrays of hashtables as well since you provide 1 per file you want to pass parameters to.