### PR TITLE
Update to correctly generate code cov from specified folder - fixes #330

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -41,3 +41,5 @@ Releases
 - 6.3.x - Engineering test same as 7.0.x
 - 7.0.x - PR287 changed included version of 4x Pester from 4.0.8 to 4.3.1, incremented major version as change of advanced options blocks auto update.
 - 7.1.x - Added additionalModulePath and CodeCoverageFolder, to support testing compiled modules ([PR#285](https://github.com/rfennell/vNextBuild/pull/285))
+- 7.2.x - Multiple fixes:
+    - Fix check for code coverage folder being specified to ensure code coverage is generated from the correct files rather than files under $ScriptFolder. ([Fixes #330](https://github.com/rfennell/vNextBuild/issues/330))

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -54,13 +54,13 @@ param
             }
         })]
     [string]$CodeCoverageOutputFile,
-    
+
     [string]$CodeCoverageFolder,
 
     [string]$ForceUseOfPesterInTasks
 )
 
-Import-Module -Name "$PSScriptRoot\HelperModule.psm1" -Force 
+Import-Module -Name "$PSScriptRoot\HelperModule.psm1" -Force
 
 if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86") {
     # Get the command parameters
@@ -135,7 +135,7 @@ if ($ExcludeTag) {
     $Parameters.Add('ExcludeTag', $ExcludeTag)
 }
 if ($CodeCoverageOutputFile -and (Get-Module Pester).Version -ge '4.0.4') {
-    if (-not $PSBoundParameters.ContainsKey('CodeCoverageFiles')) {
+    if (-not $PSBoundParameters.ContainsKey('CodeCoverageFolder')) {
         $CodeCoverageFolder = $scriptFolder
     }
     $Files = Get-ChildItem -Path $CodeCoverageFolder -include *.ps1, *.psm1 -Exclude *.Tests.ps1 -Recurse |

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -142,6 +142,10 @@ Describe "Testing Pester Task" {
             New-Item -Path $CodeCoverageOutputFile -ItemType File
         } -ParameterFilter {$CodeCoverageOutputFile -and $CodeCoverageOutputFile -eq 'TestDrive:\codecoverage2.xml' -and $CodeCoverageFolder}
 
+        mock Invoke-Pester {
+            New-Item -Path $CodeCoverageOutputFile -ItemType File
+        } -ParameterFilter {$CodeCoverageOutputFile -and $CodeCoverageOutputFile -eq 'TestDrive:\codecoverage3.xml' -and $CodeCoverageFolder}
+
         mock Invoke-Pester {}
 
         it "Creates the output xml file correctly" {
@@ -174,6 +178,20 @@ Describe "Testing Pester Task" {
             Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
 
             Assert-MockCalled -CommandName Invoke-Pester -ParameterFilter {$CodeCoverage -and $CodeCoverage -contains "$((Get-Item 'TestDrive:\').FullName)Source\Code.ps1"}
+        }
+
+        it "Creates the CodeCoverage output file for the specified files" {
+            New-Item -Path TestDrive:\ -Name Tests -ItemType Directory -Force| Out-Null
+            New-Item -Path TestDrive:\Tests -Name TestFile1.ps1 -Force | Out-Null
+            New-Item -Path TestDrive:\Tests -Name TestFile2.ps1 -Force | Out-Null
+            New-Item -Path TestDrive:\Tests -Name TestFile3.ps1 -Force | Out-Null
+            New-Item -Path TestDrive:\ -Name Source -ItemType Directory -Force | Out-Null
+            New-Item -Path TestDrive:\Source -Name Code.ps1 -Force | Out-Null
+
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage3.xml' -CodeCoverageFolder 'TestDrive:\Source' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
+
+            Assert-MockCalled -CommandName Invoke-Pester -ParameterFilter {$CodeCoverage -and $CodeCoverage -eq "$((Get-Item 'TestDrive:\').FullName)Source\Code.ps1" -and $CodeCoverage -notlike "$((Get-Item 'TestDrive:\').FullName)Tests\*.ps1"}
         }
 
     }

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -138,6 +138,10 @@ Describe "Testing Pester Task" {
             New-Item -Path $CodeCoverageOutputFile -ItemType File
         } -ParameterFilter {$CodeCoverageOutputFile -and $CodeCoverageOutputFile -eq 'TestDrive:\codecoverage.xml'}
 
+        mock Invoke-Pester {
+            New-Item -Path $CodeCoverageOutputFile -ItemType File
+        } -ParameterFilter {$CodeCoverageOutputFile -and $CodeCoverageOutputFile -eq 'TestDrive:\codecoverage2.xml' -and $CodeCoverageFolder}
+
         mock Invoke-Pester {}
 
         it "Creates the output xml file correctly" {
@@ -156,6 +160,20 @@ Describe "Testing Pester Task" {
 
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage.xml' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
             Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
+        }
+
+        it "Creates the CodeCoverage output file when code coverage folder is not specified" {
+            New-Item -Path TestDrive:\ -Name Tests -ItemType Directory | Out-Null
+            New-Item -Path TestDrive:\Tests -Name TestFile1.ps1 | Out-Null
+            New-Item -Path TestDrive:\Tests -Name TestFile2.ps1 | Out-Null
+            New-Item -Path TestDrive:\Tests -Name TestFile3.ps1 | Out-Null
+            New-Item -Path TestDrive:\ -Name Source -ItemType Directory | Out-Null
+            New-Item -Path TestDrive:\Source -Name Code.ps1 | Out-Null
+
+            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output2.xml -CodeCoverageOutputFile 'TestDrive:\codecoverage2.xml' -ForceUseOfPesterInTasks "True" -PesterVersion '4.3.1'
+            Test-Path -Path TestDrive:\codecoverage.xml | Should -Be $True
+
+            Assert-MockCalled -CommandName Invoke-Pester -ParameterFilter {$CodeCoverage -and $CodeCoverage -contains "$((Get-Item 'TestDrive:\').FullName)Source\Code.ps1"}
         }
 
     }


### PR DESCRIPTION
### What problem does this PR address?
Fixes #330 as the if check was using the wrong key name to check for, resulting in the code coverage always being based on the ScriptFolder which might be different to the test folder.