### PR TITLE
Pester parameter logging swapped to Write-Host - fixes #320

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -41,3 +41,5 @@ Releases
 - 6.3.x - Engineering test same as 7.0.x
 - 7.0.x - PR287 changed included version of 4x Pester from 4.0.8 to 4.3.1, incremented major version as change of advanced options blocks auto update.
 - 7.1.x - Added additionalModulePath and CodeCoverageFolder, to support testing compiled modules ([PR#285](https://github.com/rfennell/vNextBuild/pull/285))
+- 7.2.x - Multiple fixes:
+    - Swap logging to use Write-Host to ensure it logs out by default. ([Fixes #320](https://github.com/rfennell/vNextBuild/issues/320))

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -92,7 +92,7 @@ if (([bool]::Parse($ForceUseOfPesterInTasks) -eq $true) -and $(-not([string]::Is
     # have to use a version in this task
     $moduleFolder = "$PSScriptRoot\$pesterVersion"
     Write-Host "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension"
-    Import-Module -Name $moduleFolder\Pester.psd1 -Verbose:$False
+    Import-Module -Name $moduleFolder\Pester.psd1 4>$null
 }
 elseif ([string]::IsNullOrEmpty($moduleFolder) -and
     (-not(Get-Module -ListAvailable Pester))) {
@@ -100,15 +100,15 @@ elseif ([string]::IsNullOrEmpty($moduleFolder) -and
     # have to use a version in this task
     $moduleFolder = "$PSScriptRoot\$pesterVersion"
     Write-Host "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension, as not installed on PC"
-    Import-Module $moduleFolder\Pester.psd1 -Verbose:$False
+    Import-Module $moduleFolder\Pester.psd1 4>$null
 }
 elseif ($moduleFolder) {
     Write-Host "Loading Pester module from [$moduleFolder] using user specificed overrided location"
-    Import-Module $moduleFolder\Pester.psd1 -Verbose:$False
+    Import-Module $moduleFolder\Pester.psd1 4>$null
 }
 else {
     Write-Host "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location"
-    Import-Module Pester -Verbose:$False
+    Import-Module Pester 4>$null
 }
 
 $Parameters = @{

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -54,13 +54,13 @@ param
             }
         })]
     [string]$CodeCoverageOutputFile,
-    
+
     [string]$CodeCoverageFolder,
 
     [string]$ForceUseOfPesterInTasks
 )
 
-Import-Module -Name "$PSScriptRoot\HelperModule.psm1" -Force 
+Import-Module -Name "$PSScriptRoot\HelperModule.psm1" -Force
 
 if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86") {
     # Get the command parameters
@@ -92,7 +92,7 @@ if (([bool]::Parse($ForceUseOfPesterInTasks) -eq $true) -and $(-not([string]::Is
     # have to use a version in this task
     $moduleFolder = "$PSScriptRoot\$pesterVersion"
     Write-Verbose "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension" -verbose
-    Import-Module -Name $moduleFolder\Pester.psd1
+    Import-Module -Name $moduleFolder\Pester.psd1 -Verbose:$False
 }
 elseif ([string]::IsNullOrEmpty($moduleFolder) -and
     (-not(Get-Module -ListAvailable Pester))) {
@@ -100,15 +100,15 @@ elseif ([string]::IsNullOrEmpty($moduleFolder) -and
     # have to use a version in this task
     $moduleFolder = "$PSScriptRoot\$pesterVersion"
     Write-Verbose "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension, as not installed on PC" -verbose
-    Import-Module $moduleFolder\Pester.psd1
+    Import-Module $moduleFolder\Pester.psd1 -Verbose:$False
 }
 elseif ($moduleFolder) {
     Write-Verbose "Loading Pester module from [$moduleFolder] using user specificed overrided location" -verbose
-    Import-Module $moduleFolder\Pester.psd1
+    Import-Module $moduleFolder\Pester.psd1 -Verbose:$False
 }
 else {
     Write-Verbose "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location"
-    Import-Module Pester
+    Import-Module Pester -Verbose:$False
 }
 
 $Parameters = @{

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -80,10 +80,10 @@ if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86") {
     &"$env:windir\syswow64\windowspowershell\v1.0\powershell.exe" -noprofile -executionpolicy bypass -file $myinvocation.Mycommand.path $args
     exit
 }
-write-verbose "Running in $($env:Processor_Architecture) PowerShell" -verbose
+Write-Host "Running in $($env:Processor_Architecture) PowerShell"
 
 if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
-    Write-Verbose "Adding additional module path [$additionalModulePath] to `$env:PSModulePath" -verbose
+    Write-Host "Adding additional module path [$additionalModulePath] to `$env:PSModulePath"
     $env:PSModulePath = $additionalModulePath + ';' + $env:PSModulePath
 }
 
@@ -91,7 +91,7 @@ if (([bool]::Parse($ForceUseOfPesterInTasks) -eq $true) -and $(-not([string]::Is
     # we have no module path specified and Pester is not installed on the PC
     # have to use a version in this task
     $moduleFolder = "$PSScriptRoot\$pesterVersion"
-    Write-Verbose "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension" -verbose
+    Write-Host "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension"
     Import-Module -Name $moduleFolder\Pester.psd1 -Verbose:$False
 }
 elseif ([string]::IsNullOrEmpty($moduleFolder) -and
@@ -99,15 +99,15 @@ elseif ([string]::IsNullOrEmpty($moduleFolder) -and
     # we have no module path specified and Pester is not installed on the PC
     # have to use a version in this task
     $moduleFolder = "$PSScriptRoot\$pesterVersion"
-    Write-Verbose "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension, as not installed on PC" -verbose
+    Write-Host "Loading Pester module from [$moduleFolder] using module PSM shipped in VSTS extension, as not installed on PC"
     Import-Module $moduleFolder\Pester.psd1 -Verbose:$False
 }
 elseif ($moduleFolder) {
-    Write-Verbose "Loading Pester module from [$moduleFolder] using user specificed overrided location" -verbose
+    Write-Host "Loading Pester module from [$moduleFolder] using user specificed overrided location"
     Import-Module $moduleFolder\Pester.psd1 -Verbose:$False
 }
 else {
-    Write-Verbose "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location"
+    Write-Host "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location"
     Import-Module Pester -Verbose:$False
 }
 
@@ -119,10 +119,10 @@ $Parameters = @{
 
 if (test-path -path $scriptFolder)
 {
-    Write-Verbose "Running Pester from the folder [$scriptFolder] output sent to [$resultsFile]" -verbose
+    Write-Host "Running Pester from the folder [$scriptFolder] output sent to [$resultsFile]"
     $Parameters.Add("Script", $scriptFolder)
 } else {
-    Write-Verbose "Running Pester from using the script parameter [$scriptFolder] output sent to [$resultsFile]" -verbose
+    Write-Host "Running Pester from using the script parameter [$scriptFolder] output sent to [$resultsFile]"
     $Parameters.Add("Script", (Get-HashtableFromString -line $scriptFolder))
 }
 

--- a/Extensions/Pester/test/PesterTask/Parameters.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Parameters.Tests.ps1
@@ -1,0 +1,9 @@
+param (
+    $TestValue
+)
+
+Describe 'Main tests for Parameters.Tests.ps1' {
+    It "Should correctly output $TestValue as `$TestValue" {
+        $TestValue | Should -Be $TestValue
+    }
+}

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -12,6 +12,7 @@ Describe "Testing Pester Task" {
             {&$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\RandomFolder } | Should -Throw
         }
         it "Throws Exception when passed an invalid file type for ResultsFile" {
+            Mock -CommandName Write-Host -MockWith {}
             {&$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml} | Should -Throw
         }
         it "ResultsFile is Mandatory" {
@@ -47,7 +48,7 @@ Describe "Testing Pester Task" {
         it "Calls Invoke-Pester with multiple Tags specified" {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
 
@@ -62,7 +63,7 @@ Describe "Testing Pester Task" {
         it "Calls Invoke-Pester with multiple ExcludeTags specified" {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
 
@@ -75,7 +76,7 @@ Describe "Testing Pester Task" {
         it "Handles CodeCoverageOutputFile being null from VSTS" {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
 
@@ -93,7 +94,7 @@ Describe "Testing Pester Task" {
         mock Invoke-Pester { "ExcludeTag" } -ParameterFilter {$ExcludeTag -and $ExcludeTag -eq 'Example'}
         mock Invoke-Pester { "AllTests" }
         mock Import-Module { }
-        Mock Write-Verbose { }
+        Mock Write-Host { }
         Mock Write-Warning { }
         Mock Write-Error { }
 
@@ -122,18 +123,18 @@ Describe "Testing Pester Task" {
 
             $Env:PSModulePath | Should -Match ';{0,1}TestDrive:\\TestFolder;{0,1}'
         }
-        it "Should write-verbose the contents of Script parameters as a string version of a hashtable when a hashtable is provided" {
+        it "Should Write-Host the contents of Script parameters as a string version of a hashtable when a hashtable is provided" {
             $Parameters = "@{Path = '$PSScriptRoot\parameters.tests.ps1';Parameters=@{TestValue='SomeValue'}}"
             &$Sut -ScriptFolder $Parameters -ResultsFile TestDrive:\Output.xml -ForceUseOfPesterInTasks 'True'
 
-            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter {
-                $Message -eq "Running Pester from using the script parameter [$Parameters] output sent to [TestDrive:\Output.xml]"
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter {
+                $Object -eq "Running Pester from using the script parameter [$Parameters] output sent to [TestDrive:\Output.xml]"
             }
         }
     }
 
     Context "Testing Task Output" {
-        Mock Write-Verbose { }
+        Mock Write-Host { }
         Mock Write-Warning { }
         Mock Import-Module { }
         Mock Write-Error { }
@@ -173,7 +174,7 @@ Describe "Testing Pester Task" {
         it "Loads Pester version contained in task when ForceUse is set to true " {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
             Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
@@ -188,7 +189,7 @@ Describe "Testing Pester Task" {
         it "Loads Pester version contained in task as Pester not installed on agent and ModuleFolder is Null " {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
             Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
@@ -203,7 +204,7 @@ Describe "Testing Pester Task" {
         it "Loads Pester version contained in task when ForceUse is set to true even when ModuleFolder is set " {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
 
@@ -219,7 +220,7 @@ Describe "Testing Pester Task" {
         it "Loads Pester version contained in task as Pester not installed on agent and ModuleFolder contains whitespace " {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
             Mock Test-Path { return $true } -ParameterFilter { $Path.EndsWith("\4.3.1") }
@@ -234,7 +235,7 @@ Describe "Testing Pester Task" {
         it "Loads Pester version specified by ModuleFolder " {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
 
@@ -246,14 +247,14 @@ Describe "Testing Pester Task" {
         it "Loads default Pester version if ModuleFolder and Force use of task contained version not set" {
             mock Invoke-Pester { }
             mock Import-Module { }
-            Mock Write-Verbose { }
+            Mock Write-Host { }
             Mock Write-Warning { }
             Mock Write-Error { }
 
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ForceUseOfPesterInTasks "False"
             Assert-MockCalled  Import-Module
             # can't check the previous assert for empty parameters, so check the message
-            Assert-MockCalled Write-Verbose -ParameterFilter { $Message -eq "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location" }
+            Assert-MockCalled Write-Host -ParameterFilter { $Object -eq "No Pester module location parameters passed, and not forcing use of Pester in task, so using Powershell default module location" }
             Assert-MockCalled Invoke-Pester
         }
 

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -122,6 +122,14 @@ Describe "Testing Pester Task" {
 
             $Env:PSModulePath | Should -Match ';{0,1}TestDrive:\\TestFolder;{0,1}'
         }
+        it "Should write-verbose the contents of Script parameters as a string version of a hashtable when a hashtable is provided" {
+            $Parameters = "@{Path = '$PSScriptRoot\parameters.tests.ps1';Parameters=@{TestValue='SomeValue'}}"
+            &$Sut -ScriptFolder $Parameters -ResultsFile TestDrive:\Output.xml -ForceUseOfPesterInTasks 'True'
+
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter {
+                $Message -eq "Running Pester from using the script parameter [$Parameters] output sent to [TestDrive:\Output.xml]"
+            }
+        }
     }
 
     Context "Testing Task Output" {


### PR DESCRIPTION
Logging was using Write-Verbose but that doesn't output correctly in a build without System.Debug = True, which also forces all the other stuff to be verbose and can pollute the logs with tons of stuff you don't care about.

Using Write-Host ensures it#'s actually logging things out properly without System.Debug