### PR TITLE
Fix to always check PSgallery for latest version in case of multiple repos

### DIFF
--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -68,7 +68,7 @@ if ((Get-Module -Name PowerShellGet -ListAvailable) -and (Get-Command Install-Mo
     catch {
         Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
     }
-    $NewestPester = Find-Module -Name Pester
+    $NewestPester = Find-Module -Name Pester -Repository PSGallery
     If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
         Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery -SkipPublisherCheck
     }


### PR DESCRIPTION
If there are multiple repos available to a build agent then the returned object from Find-Module will be an array which won't correctly compare against a normal version number. As we're assuming we'll install from the PSGallery then the task should use that as it's latest version too.