### PR TITLE
Added additional logging to VersionDotNetCoreAssembliesTask because it was logging the fact the csproj file had the version applied when it hasn't because addDefault is false by default.

### DIFF
--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask/src/AppyVersionToAssembliesFunctions.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask/src/AppyVersionToAssembliesFunctions.ts
@@ -75,10 +75,11 @@ function UpdateSingleField(file, field, newVersion) {
 }
 
 export function ProcessFile(file, field, newVersion, addDefault = false) {
-
+	var isVersionApplied: any = false;
     // Check that the field to update is present
     if (field && field.length > 0) {
         UpdateSingleField(file, field, newVersion);
+		isVersionApplied = true;
     } else {
         console.log(`Checking if any version fields to update`);
         var filecontent = fs.readFileSync(file);
@@ -103,12 +104,20 @@ export function ProcessFile(file, field, newVersion, addDefault = false) {
         });
         if (hasUpdateFields === true) {
             fs.writeFileSync(file, content);
+			isVersionApplied = true;
         } else {
             if (addDefault === true) {
-                console.log(`No version fields present, so add a version field`);
+                console.log(`No version fields present, so add a Version field`);
                 UpdateSingleField(file, "Version", newVersion);
-            }
+				isVersionApplied = true;
+            } else {
+                console.log(`No version fields present, version field ignored because 'addDefault' is false`);
+			}
         }
     }
-    console.log (`${file} - version applied`);
+	if (isVersionApplied) {
+		console.log (`${file} - version applied`);
+	} else {
+		console.log (`${file} - version not applied`);
+	}
 }

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -86,3 +86,4 @@ The Android manifest versioner takes the following extra parameters:
 - V1.38   - Issue #302 enhancement .NETCore versioner to add VERSION tag of no other version fields present (defaults off)
 - V1.39   - V1.38 introductions some nasty regressions, based around not checking project type, this fixes those
 - V1.40   - Added the PowerShell Module versioning task
+- V1.50   - PR340 @philmh-isams added more logging to VersionDotNetCoreAssembliesTask 


### PR DESCRIPTION
Added additional logging to VersionDotNetCoreAssembliesTask because it was logging the fact the csproj file had the version applied when it hasn't because addDefault is false by default.

### What problem does this PR address?
Describes all actions being carried out and therefore advises how to resolve any unexpected behaviour.
  
### Is there a related Issue?
335
  
### Have you...
I have not done this, sorry. Let me know if you would prefer me to do this.