### PR TITLE
Fix powershell versioning task

### DIFF
--- a/Extensions/Versioning/VersionPowerShellModule/src/Update-PowerShellModuleVersion.ps1
+++ b/Extensions/Versioning/VersionPowerShellModule/src/Update-PowerShellModuleVersion.ps1
@@ -55,20 +55,22 @@ if (Get-Module -Name PowerShellGet -ListAvailable) {
     If ((Get-Module Configuration -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
         Write-Verbose -Message "Newer version of the module is available online, installing as current user"
         Install-Module -Name Configuration -Scope CurrentUser -Force -Repository PSGallery
-        Import-Module Configuration
+        Import-Module Configuration -force
+        $Null = Get-Command -Module Configuration
     }
 }
 else {
     Write-Verbose -Message "PowerShellGet is unavailable, using Configuration module shipped with task instead"
     Import-Module "$PSScriptRoot\1.3.0\Configuration.psd1" -force
+    $Null = Get-Command -Module Configuration
 }
 
 Write-Verbose -Message "Finding all the module psd1 files in the specified path"
 $ModuleFiles = Get-ChildItem -Path $Path -Filter *.psd1 -Recurse |
     Select-String -Pattern 'RootModule' |
-    Select-Object -ExpandProperty Path
+    Select-Object -ExpandProperty Path -Unique
 
-Write-Verbose "Found $($ModuleFiles.Count) dacpacs. Beginning to apply updated version number $VersionNumber."
+Write-Verbose "Found $($ModuleFiles.Count) modules. Beginning to apply updated version number $VersionNumber."
 
 Foreach ($Module in $ModuleFiles)
 {

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -86,4 +86,5 @@ The Android manifest versioner takes the following extra parameters:
 - V1.38   - Issue #302 enhancement .NETCore versioner to add VERSION tag of no other version fields present (defaults off)
 - V1.39   - V1.38 introductions some nasty regressions, based around not checking project type, this fixes those
 - V1.40   - Added the PowerShell Module versioning task
-- V1.41   - PR340 @philmh-isams added more logging to VersionDotNetCoreAssembliesTask 
+- V1.41   - PR340 @philmh-isams added more logging to VersionDotNetCoreAssembliesTask
+  - Fix a bug with PowerShell versioning not loading Configuration module correctly.


### PR DESCRIPTION
Configuration module is not correctly loading when using Import-Module so use Get-Command to enumerate the available commands.

Fix a typo as well.