### PR TITLE
update default path variable to work in build and release - Fixes #350

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -44,3 +44,4 @@ Releases
     - Swap logging to use Write-Host to ensure it logs out by default. ([Fixes #320](https://github.com/rfennell/vNextBuild/issues/320))
     - Change Hashtable parsing function to use language parser to handle more cases. ([Fixes #321](https://github.com/rfennell/vNextBuild/issues/321))
 - 8.0.x - Removed complicated version loading logic and replaced with installing the latest version from the gallery if you're on PSv5+ or have PowerShellGet available. If neither of those are options then it will load the 4.3.1 version of Pester that ships with the task. ([PR#314](https://github.com/rfennell/vNextBuild/pull/314))
+- 8.1.x - Fixed the default working folder to System.DefaultWorkingDirectory as this is a variable available in both build and release. ([Fixes #350](https://github.com/rfennell/vNextBuild/issues/350))

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -6,7 +6,12 @@ param
 
     [Parameter(Mandatory)]
     [ValidateScript( {
-            (Test-Path (Split-Path $_ -Parent)) -and ($_.split('.')[-1] -eq 'xml')
+            if ((Test-Path (Split-Path $_ -Parent)) -and ($_.split('.')[-1] -eq 'xml')) {
+                $true
+            }
+            else {
+                Throw 'Path is invalid or results file does not end in .xml'
+            }
         })]
     [string]$resultsFile,
 

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -10,7 +10,7 @@ param
                 $true
             }
             else {
-                Throw 'Path is invalid or results file does not end in .xml'
+                Throw "Path is invalid or results file does not end in .xml ($_)"
             }
         })]
     [string]$resultsFile,

--- a/Extensions/Pester/task/task.json
+++ b/Extensions/Pester/task/task.json
@@ -34,15 +34,15 @@
       "name": "scriptFolder",
       "type": "string",
       "label": "Scripts Folder or Script",
-      "defaultValue": "$(Build.SourcesDirectory)\\*",
+      "defaultValue": "$(System.DefaultWorkingDirectory)\\*",
       "required": true,
-      "helpMarkDown": "Folder to run scripts from e.g $(Build.SourcesDirectory)\\* or a script hashtable @{Path='$(Build.SourcesDirectory)'; Parameters=@{param1='111'; param2='222'}}"
+      "helpMarkDown": "Folder to run scripts from e.g $(System.DefaultWorkingDirectory)\\* or a script hashtable @{Path='$(System.DefaultWorkingDirectory)'; Parameters=@{param1='111'; param2='222'}}"
     },
     {
       "name": "resultsFile",
       "type": "string",
       "label": "Results File",
-      "defaultValue": "$(Build.SourcesDirectory)\\Test-Pester.XML",
+      "defaultValue": "$(System.DefaultWorkingDirectory)\\Test-Pester.XML",
       "required": true,
       "helpMarkDown": "Results File (nUnit format)"
     },


### PR DESCRIPTION
Default path variable Build.SourceDirectory is only a valid variable in build. This updates the path to use System.DefaultWorkingDirectory which is available in both.

Also tidied up the error message produced by the ValidateScript on ResultsFile to make it more obvious why it failed.