### PR TITLE
Fix version check in Pester task.

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -45,3 +45,4 @@ Releases
     - Change Hashtable parsing function to use language parser to handle more cases. ([Fixes #321](https://github.com/rfennell/vNextBuild/issues/321))
 - 8.0.x - Removed complicated version loading logic and replaced with installing the latest version from the gallery if you're on PSv5+ or have PowerShellGet available. If neither of those are options then it will load the 4.3.1 version of Pester that ships with the task. ([PR#314](https://github.com/rfennell/vNextBuild/pull/314))
 - 8.1.x - Fixed the default working folder to System.DefaultWorkingDirectory as this is a variable available in both build and release. ([Fixes #350](https://github.com/rfennell/vNextBuild/issues/350))
+- 8.3.x - Fixed the version number comparison for Code Coverage so it should no longer incorrectly warn when a version is newer than 4.0.4 [Fixes #356](https://github.com/rfennell/vNextBuild/issues/356)

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -77,6 +77,7 @@ if ((Get-Module -Name PowerShellGet -ListAvailable) -and (Get-Command Install-Mo
     If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
         Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery -SkipPublisherCheck
     }
+    Import-Module -Name Pester
 }
 else {
     Import-Module "$PSScriptRoot\4.3.1\Pester.psd1" -force

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -120,7 +120,7 @@ if ($CodeCoverageOutputFile -and (Get-Module Pester).Version -ge [Version]::Pars
         Write-Warning -Message "No PowerShell files found under [$CodeCoverageFolder] to analyse for code coverage."
     }
 }
-elseif ($CodeCoverageOutputFile -and (Get-Module Pester).Version -lt '4.0.4') {
+elseif ($CodeCoverageOutputFile -and (Get-Module Pester).Version -lt [Version]::Parse('4.0.4')) {
     Write-Warning -Message "Code coverage output not supported on Pester versions before 4.0.4."
 }
 

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -105,7 +105,7 @@ if ($ExcludeTag) {
     $ExcludeTag = $ExcludeTag.Split(',').Replace('"', '').Replace("'", "")
     $Parameters.Add('ExcludeTag', $ExcludeTag)
 }
-if ($CodeCoverageOutputFile -and (Get-Module Pester).Version -ge '4.0.4') {
+if ($CodeCoverageOutputFile -and (Get-Module Pester).Version -ge [Version]::Parse('4.0.4')) {
     if (-not $PSBoundParameters.ContainsKey('CodeCoverageFolder')) {
         $CodeCoverageFolder = $scriptFolder
     }

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Testing Pester Task" {
         }
         it "Throws Exception when passed an invalid file type for ResultsFile" {
             Mock -CommandName Write-Host -MockWith {}
-            {&$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml} | Should -Throw
+            {&$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.invalid} | Should -Throw
         }
         it "ResultsFile is Mandatory" {
             (Get-Command $sut).Parameters['ResultsFile'].Attributes.Mandatory | Should -Be $True
@@ -268,7 +268,9 @@ Describe "Testing Pester Task" {
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
 
             Assert-MockCalled Install-Module -Times 0 -Scope It
+            Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -like '*\4.3.1\Pester.psd1'}
             Assert-MockCalled Invoke-Pester
+            Assert-MockCalled Write-Warning -Times 0 -ParameterFilter {$Message -eq "Code coverage output not supported on Pester versions before 4.0.4."}
         }
         <#it "Loads Pester version that ships with task when not on PS5+ or PowerShellGet is unavailable" {
             mock Invoke-Pester { }


### PR DESCRIPTION
Version checking was looking at strings and sometimes having issues when the version was higher but the string didn't correctly compare as being higher.