### PR TITLE
Add support for PowerShell v4 and lower in hashtable parsing

### DIFF
--- a/Extensions/Pester/task/HelperModule.psm1
+++ b/Extensions/Pester/task/HelperModule.psm1
@@ -11,9 +11,17 @@ function Get-HashtableFromString
     }
 
     Foreach ($line in ($lineInput -split '(?<=}\s*),')) {
-        # Use the language parser to safely parse the hashtable string into a real hashtable.
-        [System.Management.Automation.Language.Parser]::ParseInput($line, [Ref]$null, [Ref]$null).Find({
+        $Hashtable = [System.Management.Automation.Language.Parser]::ParseInput($line, [Ref]$null, [Ref]$null).Find({
             $args[0] -is [System.Management.Automation.Language.HashtableAst]
-        }, $false).SafeGetValue()
+        }, $false)
+
+        if ($PSVersionTable.PSVersion.Major -ge 5) {
+            # Use the language parser to safely parse the hashtable string into a real hashtable.
+            $Hashtable.SafeGetValue()
+        }
+        else {
+            Write-Warning -Message "PowerShell Version lower than 5 detected. Performing Unsafe hashtable conversion. Please update to version 5 or above when possible for safe conversion of hashtable."
+            Invoke-Expression -Command $Hashtable.Extent
+        }
     }
 }


### PR DESCRIPTION
SafeGetValue doesn't exist in lower versions of PowerShell which is
causing exceptions when trying to run the HelperModule.
