### PR TITLE
Fix repository Pester is downloaded from

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -47,3 +47,4 @@ Releases
 - 8.1.x - Fixed the default working folder to System.DefaultWorkingDirectory as this is a variable available in both build and release. ([Fixes #350](https://github.com/rfennell/vNextBuild/issues/350))
 - 8.3.x - Fixed the version number comparison for Code Coverage so it should no longer incorrectly warn when a version is newer than 4.0.4 [Fixes #356](https://github.com/rfennell/vNextBuild/issues/356)
 - 8.4.x - Fixed the hashtable conversion for lower versions of PowerShell. Sadly this makes use of Invoke-Expression but there is a warning that it is an unsafe operation and the build agent should be upgraded to v5 when possible. [Fixes #358](https://github.com/rfennell/vNextBuild/issues/358)
+- 8.6.x - Fixed the installation of Pester from the PSGallery to use the first available PS Repository so it handles situations where only a private repository is available. [Fixes #366](https://github.com/rfennell/vNextBuild/issues/366)

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -73,9 +73,10 @@ if ((Get-Module -Name PowerShellGet -ListAvailable) -and (Get-Command Install-Mo
     catch {
         Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
     }
-    $NewestPester = Find-Module -Name Pester -Repository PSGallery
+    $Respository = Get-PSRepository | Select-Object -First 1
+    $NewestPester = Find-Module -Name Pester -Repository $Respository.Name
     If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
-        Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery -SkipPublisherCheck
+        Install-Module -Name Pester -Scope CurrentUser -Force -Repository $Respository.Name -SkipPublisherCheck
     }
     Import-Module -Name Pester
 }

--- a/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
+++ b/Extensions/Pester/test/PesterTask/Pester.Tests.ps1
@@ -45,6 +45,7 @@ Describe "Testing Pester Task" {
             Mock Install-Module { }
             Mock Find-Module { }
             Mock Get-PackageProvider { $True }
+            Mock Get-PSRepository {[PSCustomObject]@{Name = 'PSGallery'}}
 
             . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -Tag 'Infrastructure,Integration'
             $Tag.Length | Should Be 2
@@ -63,6 +64,7 @@ Describe "Testing Pester Task" {
             Mock Install-Module { }
             Mock Find-Module { }
             Mock Get-PackageProvider { $True }
+            Mock Get-PSRepository {[PSCustomObject]@{Name = 'PSGallery'}}
 
             . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml -ExcludeTag 'Example,Demo'
             $ExcludeTag.Length | Should be 2
@@ -79,6 +81,7 @@ Describe "Testing Pester Task" {
             Mock Install-Module { }
             Mock Find-Module { }
             Mock Get-PackageProvider { $True }
+            Mock Get-PSRepository {[PSCustomObject]@{Name = 'PSGallery'}}
 
             . $Sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\Output.xml -CodeCoverageOutputFile $null
             Assert-MockCalled Invoke-Pester
@@ -100,6 +103,7 @@ Describe "Testing Pester Task" {
         Mock Install-Module { }
         Mock Find-Module { }
         Mock Get-PackageProvider { $True }
+        Mock Get-PSRepository {[PSCustomObject]@{Name = 'PSGallery'}}
 
         it "Calls Invoke-Pester correctly with ScriptFolder and ResultsFile specified" {
             &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
@@ -142,6 +146,7 @@ Describe "Testing Pester Task" {
         Mock Import-Module { }
         Mock Install-Module { }
         Mock Write-Error { }
+        Mock Get-PSRepository {[PSCustomObject]@{Name = 'PSGallery'}}
         mock Invoke-Pester {
             param ($OutputFile)
             New-Item -Path $OutputFile -ItemType File
@@ -218,6 +223,7 @@ Describe "Testing Pester Task" {
         Mock Install-Module { $true }
         Mock Write-host { }
         Mock Write-Warning { }
+        Mock Get-PSRepository {[PSCustomObject]@{Name = 'PSGallery'}}
         Mock Write-Error { }
         Mock Get-Command { [PsCustomObject]@{Parameters=@{SkipPublisherCheck='SomeValue'}}}
 


### PR DESCRIPTION
PSGallery isn't always available so this will choose the first available repository and use that.