### PR TITLE
ensure versionCode is not set to 0 - Fixes #387

### DIFF
--- a/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifest.ts
+++ b/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifest.ts
@@ -63,6 +63,9 @@ const versionCode = getSplitVersionParts(versionRegex, versionCodeFormat, newVer
 if (parseInt(versionCode, 10) >= 2100000000) {
     tl.error(`Version Code of ${versionCode} is too long, must be below 2100000000 for submission to Google Play Store`);
     process.exit(1);
+} else if (parseInt(versionCode, 0) === 0) {
+    tl.error(`Version Code cannot be 0. Please ensure the value is greater than 0 and increments to unique numbers.`);
+
 } else {
     console.log (`Version Code will be ${versionCode}`);
 }

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -89,3 +89,4 @@ The Android manifest versioner takes the following extra parameters:
 - V1.41   - PR340 @philmh-isams added more logging to VersionDotNetCoreAssembliesTask
   - Fix a bug with PowerShell versioning not loading Configuration module correctly.
 - V1.42   - Fix a logic issue with the PowerShell versioning task not installing the Configuration module.
+- V2.1.x  - Fix Android Versioning task from assigning a 0 to VersionCode, build will now fail if it is.


### PR DESCRIPTION
### What problem does this PR address?
If the versionCode is 0 then it's not accepted, the build should fail if this is the case.
  
### Is there a related Issue?
#387
  
### Have you...
- [x] Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
 - [x] increments the minor version number e.g. 1.2 to 1.3
 - [x] lists the Issue/PR number related to the change
 - [x] provides a brief single line comment as to the change made
 - [ ] if the change adds new parameters update the appropriate documentation
- [x] If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
